### PR TITLE
Added quotes to ETag value

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/AzureBlobMediaMiddleware.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/AzureBlobMediaMiddleware.cs
@@ -139,7 +139,7 @@ namespace Umbraco.StorageProviders.AzureBlob
                 };
 
             responseHeaders.LastModified = properties.Value.LastModified;
-            responseHeaders.ETag = new EntityTagHeaderValue(properties.Value.ETag.ToString());
+            responseHeaders.ETag = new EntityTagHeaderValue($"\"{properties.Value.ETag}\"");
             responseHeaders.Append(HeaderNames.Vary, "Accept-Encoding");
 
             var requestHeaders = request.GetTypedHeaders();


### PR DESCRIPTION
I was having an issue viewing images and found the issue being that the ETag was not being encapsulated in double quotes. Having tested this locally I was able to remedy it and all images started to display correctly.