### PR TITLE
Add AzureBlobFileSystemImageProvider as first provider and only match configured root path

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobMediaFileSystemExtensions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobMediaFileSystemExtensions.cs
@@ -43,8 +43,12 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
             builder.Services.TryAddSingleton<AzureBlobFileSystemMiddleware>();
 
-            // ImageSharp image provider/cache
-            builder.Services.AddUnique<IImageProvider, AzureBlobFileSystemImageProvider>();
+            // ImageSharp image providers (remove all to ensure the correct order, as PhysicalFileSystemProvider matches all requests)
+            builder.Services.RemoveAll<IImageProvider>();
+            builder.Services.AddSingleton<IImageProvider, AzureBlobFileSystemImageProvider>();
+            builder.Services.AddSingleton<IImageProvider, PhysicalFileSystemProvider>();
+
+            // ImageSharp image cache
             builder.Services.AddUnique<IImageCache, AzureBlobFileSystemImageCache>();
 
             builder.SetMediaFileSystem(provider => provider.GetRequiredService<IAzureBlobFileSystemProvider>()

--- a/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobMediaFileSystemExtensions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobMediaFileSystemExtensions.cs
@@ -43,12 +43,8 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
             builder.Services.TryAddSingleton<AzureBlobFileSystemMiddleware>();
 
-            // ImageSharp image providers (remove all to ensure the correct order, as PhysicalFileSystemProvider matches all requests)
-            builder.Services.RemoveAll<IImageProvider>();
-            builder.Services.AddSingleton<IImageProvider, AzureBlobFileSystemImageProvider>();
-            builder.Services.AddSingleton<IImageProvider, PhysicalFileSystemProvider>();
-
-            // ImageSharp image cache
+            // ImageSharp image provider/cache
+            builder.Services.Insert(0, ServiceDescriptor.Singleton<IImageProvider, AzureBlobFileSystemImageProvider>());
             builder.Services.AddUnique<IImageCache, AzureBlobFileSystemImageCache>();
 
             builder.SetMediaFileSystem(provider => provider.GetRequiredService<IAzureBlobFileSystemProvider>()


### PR DESCRIPTION
This fixes https://github.com/umbraco/Umbraco.StorageProviders/issues/16 by making sure the `PhysicalFileSystemProvider` is added again after the `AzureBlobFileSystemImageProvider`, so our provider is the first and now only matches requests for the configured root path (by default `~/media`).

Follow these steps to test:
1. Configure the Azure Blob Storage provider and ensure resizing works (by uploading a media item and checking if e.g. `/media/abcd1234/test.jpg?width=100` works)
2. Add an image in the web root and check whether resizing now also works (e.g. `/test.jpg?width=100`)

-----------------
One thing to note though: static files that are added to physical `/wwwroot/media/` directory are served by the static files middleware (and even takes precedence over the files stored in Azure Blob Storage). ImageSharp.Web only uses the first provider that matches very loosely, so the `AzureBlobFileSystemImageProvider` will now resolve all processing requests to `~/media`, which only fetches the files from Azure Blob Storage.

This means that any physical files in `/wwwroot/media` won't be processed by ImageSharp.Web, which might result in very strange behavior:
1. Add different images to both Azure Blob Storage and the physical file system using the same path/file name (e.g. `/media/test.jpg`)
2. Request this URL from the browser:
  - Without query string: the image from the physical file system is returned (by the static files middleware)
  - With query string (e.g. `/media/test.jpg?width=100`): the image from Azure Blob Storage is processed and returned (by the ImageSharp middleware)

Check https://github.com/SixLabors/ImageSharp.Web/pull/185 for more information and a possible fix for this.