### PR TITLE
Add ContainerRootPath option

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileSystemMiddleware.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileSystemMiddleware.cs
@@ -379,6 +379,7 @@ namespace Umbraco.StorageProviders.AzureBlob
             if (name != _name) return;
 
             _rootPath = hostingEnvironment.ToAbsolute(options.VirtualPath);
+            _containerRootPath = options.ContainerRootPath ?? _rootPath;
         }
     }
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -21,6 +21,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
         private readonly IContentTypeProvider _contentTypeProvider;
         private readonly IIOHelper _ioHelper;
         private readonly string _rootUrl;
+        private readonly string _containerRootPath;
 
         /// <summary>
         ///     Creates a new instance of <see cref="AzureBlobFileSystem" />.
@@ -39,14 +40,8 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
             _ioHelper = ioHelper ?? throw new ArgumentNullException(nameof(ioHelper));
             _contentTypeProvider = contentTypeProvider ?? throw new ArgumentNullException(nameof(contentTypeProvider));
 
-            if(options.ContainerRootPath != null)
-            {
-                _rootUrl = options.ContainerRootPath.TrimEnd('/');
-            }
-            else
-            {
-                _rootUrl = EnsureUrlSeparatorChar(hostingEnvironment.ToAbsolute(options.VirtualPath)).TrimEnd('/');
-            }
+            _rootUrl = EnsureUrlSeparatorChar(hostingEnvironment.ToAbsolute(options.VirtualPath)).TrimEnd('/');
+            _containerRootPath = options.ContainerRootPath ?? _rootUrl;
 
             var client = new BlobServiceClient(options.ConnectionString);
             _container = client.GetBlobContainerClient(options.ContainerName);
@@ -113,7 +108,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
             if (_contentTypeProvider.TryGetContentType(path, out var contentType)) headers.ContentType = contentType;
 
             blob.Upload(stream, headers,
-                conditions: overrideIfExists ? null : new BlobRequestConditions {IfNoneMatch = new ETag("*")});
+                conditions: overrideIfExists ? null : new BlobRequestConditions { IfNoneMatch = new ETag("*") });
         }
 
         /// <inheritdoc />
@@ -131,7 +126,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
             var copyFromUriOperation = destinationBlob.StartCopyFromUri(sourceBlob.Uri,
                 destinationConditions: overrideIfExists
                     ? null
-                    : new BlobRequestConditions {IfNoneMatch = new ETag("*")});
+                    : new BlobRequestConditions { IfNoneMatch = new ETag("*") });
 
             if (copyFromUriOperation?.HasCompleted == false)
                 Task.Run(async () => await copyFromUriOperation.WaitForCompletionAsync().ConfigureAwait(false))
@@ -262,7 +257,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
         {
             if (path == null) throw new ArgumentNullException(nameof(path));
 
-            return _container.GetBlobClient(GetFullPath(path));
+            return _container.GetBlobClient(GetBlobPath(path));
         }
 
         /// <inheritdoc />
@@ -288,6 +283,26 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
             if (path == null) throw new ArgumentNullException(nameof(path));
 
             return _container.GetBlobsByHierarchy(prefix: path);
+        }
+
+        private string GetBlobPath(string path)
+        {
+            if (path == null) throw new ArgumentNullException(nameof(path));
+
+            path = EnsureUrlSeparatorChar(path);
+
+            if (_ioHelper.PathStartsWith(path, _containerRootPath, '/'))
+            {
+                return path;
+            }
+
+            if (_ioHelper.PathStartsWith(path, _rootUrl, '/'))
+            {
+                path = path[_rootUrl.Length..];
+            }
+
+            path = $"{_containerRootPath}/{path.TrimStart('/')}";
+            return path.Trim('/');
         }
     }
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -39,7 +39,14 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
             _ioHelper = ioHelper ?? throw new ArgumentNullException(nameof(ioHelper));
             _contentTypeProvider = contentTypeProvider ?? throw new ArgumentNullException(nameof(contentTypeProvider));
 
-            _rootUrl = EnsureUrlSeparatorChar(hostingEnvironment.ToAbsolute(options.VirtualPath)).TrimEnd('/');
+            if(options.ContainerRootPath != null)
+            {
+                _rootUrl = options.ContainerRootPath.TrimEnd('/');
+            }
+            else
+            {
+                _rootUrl = EnsureUrlSeparatorChar(hostingEnvironment.ToAbsolute(options.VirtualPath)).TrimEnd('/');
+            }
 
             var client = new BlobServiceClient(options.ConnectionString);
             _container = client.GetBlobContainerClient(options.ContainerName);

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptions.cs
@@ -25,6 +25,11 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
         public string ContainerName { get; set; } = null!;
 
         /// <summary>
+        /// The root path of the container.
+        /// </summary>
+        public string ContainerRootPath { get; set; } = null!;
+
+        /// <summary>
         /// The virtual path.
         /// </summary>
         [Required]


### PR DESCRIPTION
To allow users to configure the root path of their container, I added the optional ContainerRootPath option.
If it's not configured, the previous behavior will be applied which is to use the VirtualPath (Umbraco Media Path).

I tested this on my own website which is being upgraded from Umbraco 8.
The images show up in the Umbraco back-office and also in the front-end as expected when setting ContainerRootPath to '/'.

My main concern would be breaking existing users because I'm not familiar with the code base and there are no tests yet to reassure there's no regressions.

Let me know what needs to be changed!

---

PR fixes #19