### PR TITLE
Do not add container name to CDN URL

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/CdnMediaUrlProviderExtensions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/CdnMediaUrlProviderExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Umbraco.StorageProviders.AzureBlob;
-using Umbraco.StorageProviders.AzureBlob.IO;
 
 // ReSharper disable once CheckNamespace
 // uses same namespace as Umbraco Core for easier discoverability
@@ -27,16 +25,6 @@ namespace Umbraco.Cms.Core.DependencyInjection
 
             builder.Services.AddOptions<CdnMediaUrlProviderOptions>()
                 .BindConfiguration("Umbraco:Storage:AzureBlob:Media:Cdn")
-                .Configure<IOptionsFactory<AzureBlobFileSystemOptions>>(
-                    (options, factory) =>
-                    {
-                        var mediaOptions = factory.Create(AzureBlobFileSystemOptions.MediaFileSystemName);
-                        if (!string.IsNullOrEmpty(mediaOptions.ContainerName))
-                        {
-                            options.Url = new Uri(options.Url, mediaOptions.ContainerName);
-                        }
-                    }
-                )
                 .ValidateDataAnnotations();
 
             builder.MediaUrlProviders().Insert<CdnMediaUrlProvider>();


### PR DESCRIPTION
The `AddCdnMediaUrlProvider()` extension method added the Azure Blob Storage container name to the CDN URL, which could only be overwritten when using the configure callback.

Because it doesn't make sense to expose the container name in the URL, this PR removes the offending code. You can always manually add the container name back to the CDN URL, so I think this isn't a real breaking change and can be released as a new minor version.