### PR TITLE
Add CreateIfNotExists helper method for Azure Blob Storage

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -304,5 +304,24 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
             path = $"{_containerRootPath}/{path.TrimStart('/')}";
             return path.Trim('/');
         }
+
+        /// <summary>
+        /// Creates a new container under the specified account if a container with the same name does not already exist.
+        /// </summary>
+        /// <param name="options">The Azure Blob Storage file system options.</param>
+        /// <param name="accessType">Optionally specifies whether data in the container may be accessed publicly and the level of access.
+        /// <see cref="PublicAccessType.BlobContainer" /> specifies full public read access for container and blob data. Clients can enumerate blobs within the container via anonymous request, but cannot enumerate containers within the storage account.
+        /// <see cref="PublicAccessType.Blob" /> specifies public read access for blobs. Blob data within this container can be read via anonymous request, but container data is not available. Clients cannot enumerate blobs within the container via anonymous request.
+        /// <see cref="PublicAccessType.None" /> specifies that the container data is private to the account owner.</param>
+        /// <returns>
+        /// If the container does not already exist, a <see cref="Response{T}" /> describing the newly created container. If the container already exists, <see langword="null" />.
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">options</exception>
+        public static Response<BlobContainerInfo> CreateIfNotExists(AzureBlobFileSystemOptions options, PublicAccessType accessType = PublicAccessType.None)
+        {
+            if (options == null) throw new ArgumentNullException(nameof(options));
+
+            return new BlobContainerClient(options.ConnectionString, options.ContainerName).CreateIfNotExists(accessType);
+        }
     }
 }


### PR DESCRIPTION
This closes https://github.com/umbraco/Umbraco.StorageProviders/issues/6 by allowing you to (more easily) create the container if it doesn't exist yet (you need to explicitly opt-in, because it requires create/write permissions, does a service request and you need to specify the access type, see [Azure Storage Blobs](https://docs.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobcontainerclient.createifnotexists?view=azure-dotnet#azure-storage-blobs-blobcontainerclient-createifnotexists(azure-storage-blobs-models-publicaccesstype-system-collections-generic-idictionary((system-string-system-string))-azure-storage-blobs-models-blobcontainerencryptionscopeoptions-system-threading-cancellationtoken))/[legacy](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.storage.blob.cloudblobcontainer.createifnotexists?view=azure-dotnet-legacy&viewFallbackFrom=azure-dotnet#microsoft-azure-storage-blob-cloudblobcontainer-createifnotexists(microsoft-azure-storage-blob-blobcontainerpublicaccesstype-microsoft-azure-storage-blob-blobrequestoptions-microsoft-azure-storage-operationcontext)) docs).

I've not added this as an extra option to `AzureBlobFileSystemOptions`, because the creation should be done only once during runtime (so not during configuration) and also not within the `AzureBlobFileSystem` constructor. It's still best practice to ensure the configured container is already created, but this might make development/testing a bit easier.

The following code should automatically create the container on application startup:

```c#
using Microsoft.Extensions.Options;
using Umbraco.Cms.Core.Composing;
using Umbraco.StorageProviders.AzureBlob.IO;

public class AzureBlobFileSystemComposer : ComponentComposer<AzureBlobFileSystemComponent>
{ }

public class AzureBlobFileSystemComponent : IComponent
{
    private readonly IOptionsMonitor<AzureBlobFileSystemOptions> _options;

    public AzureBlobFileSystemComponent(IOptionsMonitor<AzureBlobFileSystemOptions> options) => _options = options;

    public void Initialize()
    {
        var options = _options.Get(AzureBlobFileSystemOptions.MediaFileSystemName);
        AzureBlobFileSystem.CreateIfNotExists(options);
    }

    public void Terminate()
    { }
}
```