### PR TITLE
Correctly parse ETag value, path, access conditions and use HeaderNames constants

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileSystemMiddleware.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileSystemMiddleware.cs
@@ -253,11 +253,12 @@ namespace Umbraco.StorageProviders.AzureBlob
                 }
 
                 var ifModifiedSince = request.Headers["If-Modified-Since"];
-                if (!string.IsNullOrEmpty(ifModifiedSince))
+                if (!string.IsNullOrEmpty(ifModifiedSince) &&
+                    DateTimeOffset.TryParse(ifModifiedSince, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset ifModifiedSinceDate))
                 {
                     return new BlobRequestConditions
                     {
-                        IfModifiedSince = DateTimeOffset.Parse(ifModifiedSince, CultureInfo.InvariantCulture)
+                        IfModifiedSince = ifModifiedSinceDate
                     };
                 }
             }
@@ -268,24 +269,29 @@ namespace Umbraco.StorageProviders.AzureBlob
                 var ifRange = request.Headers["If-Range"];
                 if (!string.IsNullOrEmpty(ifRange))
                 {
-                    var conditions = new BlobRequestConditions();
-
-                    if (DateTimeOffset.TryParse(ifRange, out var date))
+                    if (DateTimeOffset.TryParse(ifRange, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset ifRangeDate))
                     {
-                        conditions.IfUnmodifiedSince = date;
+                        return new BlobRequestConditions()
+                        {
+                            IfUnmodifiedSince = ifRangeDate
+                        };
                     }
                     else
                     {
-                        conditions.IfMatch = new ETag(ifRange);
+                        return new BlobRequestConditions()
+                        {
+                            IfMatch = new ETag(ifRange)
+                        };
                     }
                 }
 
                 var ifUnmodifiedSince = request.Headers["If-Unmodified-Since"];
-                if (!string.IsNullOrEmpty(ifUnmodifiedSince))
+                if (!string.IsNullOrEmpty(ifUnmodifiedSince) &&
+                    DateTimeOffset.TryParse(ifUnmodifiedSince, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTimeOffset ifUnmodifiedSinceDate))
                 {
                     return new BlobRequestConditions
                     {
-                        IfUnmodifiedSince = DateTimeOffset.Parse(ifUnmodifiedSince, CultureInfo.InvariantCulture)
+                        IfUnmodifiedSince = ifUnmodifiedSinceDate
                     };
                 }
             }

--- a/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileSystemMiddleware.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileSystemMiddleware.cs
@@ -83,13 +83,13 @@ namespace Umbraco.StorageProviders.AzureBlob
             var request = context.Request;
             var response = context.Response;
 
-            if (!context.Request.Path.StartsWithSegments(_rootPath, StringComparison.InvariantCultureIgnoreCase))
+            if (!context.Request.Path.StartsWithSegments(_rootPath, StringComparison.InvariantCultureIgnoreCase, out PathString path))
             {
                 await next(context).ConfigureAwait(false);
                 return;
             }
 
-            string containerPath = $"{_containerRootPath.TrimEnd('/')}/{(request.Path.Value.Remove(0, _rootPath.Length)).TrimStart('/')}";
+            string containerPath = $"{_containerRootPath.TrimEnd('/')}/{path.Value?.TrimStart('/')}";
             var blob = _fileSystemProvider.GetFileSystem(_name).GetBlobClient(containerPath);
 
             var blobRequestConditions = GetAccessCondition(context.Request);

--- a/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileSystemMiddleware.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileSystemMiddleware.cs
@@ -164,7 +164,12 @@ namespace Umbraco.StorageProviders.AzureBlob
                 };
 
             responseHeaders.LastModified = properties.Value.LastModified;
-            responseHeaders.ETag = new EntityTagHeaderValue(properties.Value.ETag.ToString("H"));
+
+            if (EntityTagHeaderValue.TryParse(properties.Value.ETag.ToString("H"), out EntityTagHeaderValue entityTagHeaderValue))
+            {
+                responseHeaders.ETag = entityTagHeaderValue;
+            }
+
             responseHeaders.Append(HeaderNames.Vary, "Accept-Encoding");
 
             var requestHeaders = request.GetTypedHeaders();


### PR DESCRIPTION
This fixes https://github.com/umbraco/Umbraco.StorageProviders/issues/37 by using `EntityTagHeaderValue.TryParse()` to parse the ETag value returned by Azure Blob Storage.

I've also cleaned up related code in the middleware, so the remaining path (everything after the root path) is directly retrieved from the `StartsWithSegments()` call, dates are correctly parsed and header names are using the constant values.