### PR TITLE
Remove extra slash between CDN URL and media path (using configured UmbracoMediaPath)

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/CdnMediaUrlProvider.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/CdnMediaUrlProvider.cs
@@ -43,7 +43,7 @@ namespace Umbraco.StorageProviders.AzureBlob
             return mediaUrl.IsUrl switch
             {
                 false => mediaUrl,
-                _ => UrlInfo.Url($"{_cdnUrl}/{mediaUrl.Text[(_removeMediaFromPath ? "/media/" : "/").Length..]}", culture)
+                _ => UrlInfo.Url(_cdnUrl + mediaUrl.Text[(_removeMediaFromPath ? "/media/" : "/").Length..], culture)
             };
         }
 

--- a/src/Umbraco.StorageProviders.AzureBlob/CdnMediaUrlProvider.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/CdnMediaUrlProvider.cs
@@ -1,8 +1,11 @@
 using System;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Cms.Core.Routing;
+using Umbraco.Extensions;
 
 namespace Umbraco.StorageProviders.AzureBlob
 {
@@ -14,45 +17,89 @@ namespace Umbraco.StorageProviders.AzureBlob
     {
         private bool _removeMediaFromPath;
         private Uri _cdnUrl;
+        private string _mediaPath;
 
         /// <summary>
-        /// Creates a new instance of <see cref="CdnMediaUrlProvider" />.
+        /// Initializes a new instance of the <see cref="CdnMediaUrlProvider"/> class.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <param name="globalSettings">The global settings.</param>
+        /// <param name="hostingEnvironment">The hosting environment.</param>
+        /// <param name="mediaPathGenerators">The media path generators.</param>
+        /// <param name="uriUtility">The URI utility.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="globalSettings"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="hostingEnvironment"/> is <c>null</c>.</exception>
+        public CdnMediaUrlProvider(IOptionsMonitor<CdnMediaUrlProviderOptions> options, IOptionsMonitor<GlobalSettings> globalSettings, IHostingEnvironment hostingEnvironment, MediaUrlGeneratorCollection mediaPathGenerators, UriUtility uriUtility)
+            : this(options, mediaPathGenerators, uriUtility, string.Empty)
+        {
+            if (globalSettings == null) throw new ArgumentNullException(nameof(globalSettings));
+            if (hostingEnvironment == null) throw new ArgumentNullException(nameof(hostingEnvironment));
+
+            _mediaPath = hostingEnvironment.ToAbsolute(globalSettings.CurrentValue.UmbracoMediaPath).EnsureEndsWith('/');
+
+            globalSettings.OnChange((options, name) =>
+            {
+                if (name == Options.DefaultName)
+                {
+                    _mediaPath = hostingEnvironment.ToAbsolute(options.UmbracoMediaPath).EnsureEndsWith('/');
+                }
+            });
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CdnMediaUrlProvider"/> class.
         /// </summary>
         /// <param name="options">The options.</param>
         /// <param name="mediaPathGenerators">The media path generators.</param>
         /// <param name="uriUtility">The URI utility.</param>
-        /// <exception cref="System.ArgumentNullException">options</exception>
-        public CdnMediaUrlProvider(IOptionsMonitor<CdnMediaUrlProviderOptions> options,
-            MediaUrlGeneratorCollection mediaPathGenerators, UriUtility uriUtility)
+        /// <exception cref="ArgumentNullException"><paramref name="options"/> is <c>null</c>.</exception>
+        [Obsolete("This constructor is obsolete and will be removed in a future version. Use another constructor instead.")]
+        public CdnMediaUrlProvider(IOptionsMonitor<CdnMediaUrlProviderOptions> options, MediaUrlGeneratorCollection mediaPathGenerators, UriUtility uriUtility)
+            : this(options, mediaPathGenerators, uriUtility, "/media/")
+        { }
+
+        private CdnMediaUrlProvider(IOptionsMonitor<CdnMediaUrlProviderOptions> options, MediaUrlGeneratorCollection mediaPathGenerators, UriUtility uriUtility, string mediaPath)
             : base(mediaPathGenerators, uriUtility)
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
 
             _cdnUrl = options.CurrentValue.Url;
             _removeMediaFromPath = options.CurrentValue.RemoveMediaFromPath;
+            _mediaPath = mediaPath;
 
-            options.OnChange(OptionsOnChange);
+            options.OnChange((options, name) =>
+            {
+                if (name == Options.DefaultName)
+                {
+                    _removeMediaFromPath = options.RemoveMediaFromPath;
+                    _cdnUrl = options.Url;
+                }
+            });
         }
 
         /// <inheritdoc />
         public override UrlInfo? GetMediaUrl(IPublishedContent content, string propertyAlias, UrlMode mode, string culture, Uri current)
         {
             var mediaUrl = base.GetMediaUrl(content, propertyAlias, UrlMode.Relative, culture, current);
-            if (mediaUrl == null) return null;
-
-            return mediaUrl.IsUrl switch
+            if (mediaUrl?.IsUrl == true)
             {
-                false => mediaUrl,
-                _ => UrlInfo.Url(_cdnUrl + mediaUrl.Text[(_removeMediaFromPath ? "/media/" : "/").Length..], culture)
-            };
-        }
+                string url = mediaUrl.Text;
 
-        private void OptionsOnChange(CdnMediaUrlProviderOptions options, string name)
-        {
-            if (name != Options.DefaultName) return;
+                int startIndex = 0;
+                if (_removeMediaFromPath && url.StartsWith(_mediaPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    startIndex = _mediaPath.Length;
+                }
+                else if (url.StartsWith('/'))
+                {
+                    startIndex = 1;
+                }
 
-            _removeMediaFromPath = options.RemoveMediaFromPath;
-            _cdnUrl = options.Url;
+                return UrlInfo.Url(_cdnUrl + url[startIndex..], culture);
+            }
+
+            return mediaUrl;
         }
     }
 }


### PR DESCRIPTION
As mentioned in https://github.com/umbraco/Umbraco.StorageProviders/issues/33#issuecomment-1150260781, the URL generated by the `CdnMediaUrlProvider` contained double slashes between the CDN URL and media path.

Besides fixing this, I've also backported the functionality from PR https://github.com/umbraco/Umbraco.StorageProviders/pull/36 to use the configured `UmbracoMediaPath` instead of a hard-coded `/media/` path. This should also make it easier merge this change up.