### PR TITLE
Authorize access to blob data with managed identities for Azure resources

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileProvider.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileProvider.cs
@@ -38,11 +38,13 @@ namespace Umbraco.StorageProviders.AzureBlob
         /// </summary>
         /// <param name="options">The options.</param>
         /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
+        [Obsolete("Please use: AzureBlobFileProvider(BlobContainerClient containerClient, string? containerRootPath = null)")]
         public AzureBlobFileProvider(AzureBlobFileSystemOptions options)
         {
             ArgumentNullException.ThrowIfNull(options);
 
-            _containerClient = new BlobContainerClient(options.ConnectionString, options.ContainerName);
+            // Fallback to the default implementation of IBlobContainerClientFactory.
+            _containerClient = new BlobContainerClientFactory().Build(options);
             _containerRootPath = options.ContainerRootPath?.Trim(Constants.CharArrays.ForwardSlash);
         }
 

--- a/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobFileSystemExtensions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobFileSystemExtensions.cs
@@ -89,6 +89,7 @@ namespace Umbraco.Cms.Core.DependencyInjection
             ArgumentNullException.ThrowIfNull(name);
 
             builder.Services.TryAddSingleton<IAzureBlobFileSystemProvider, AzureBlobFileSystemProvider>();
+            builder.Services.TryAddSingleton<IBlobContainerClientFactory, BlobContainerClientFactory>();
 
             var optionsBuilder = builder.Services.AddOptions<AzureBlobFileSystemOptions>(name)
                 .BindConfiguration($"Umbraco:Storage:AzureBlob:{name}")

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/BlobContainerClientFactory.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/BlobContainerClientFactory.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using Azure.Identity;
+using Azure.Storage.Blobs;
+
+namespace Umbraco.StorageProviders.AzureBlob.IO
+{
+    /// <summary>
+    /// The default <see cref="BlobContainerClient"/> factory.
+    /// </summary>
+    public class BlobContainerClientFactory : IBlobContainerClientFactory
+    {
+        /// <summary>
+        /// The Azure storage ConnectionString parser expression.
+        /// </summary>
+        /// <remarks>
+        /// Unfortunatly the official parser is internal.
+        /// </remarks>
+        private static readonly Regex ConnectionStringParser = new Regex("(?<Key>[^=]+)=(?<Value>[^;]+);?", RegexOptions.Compiled);
+
+        /// <inheritdoc/>
+        public BlobContainerClient Build(AzureBlobFileSystemOptions options)
+        {
+            if (options is null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            var connectionStringParameter = GetConnectionStringParameters(options.ConnectionString);
+            if (connectionStringParameter.TryGetValue("Authentication", out var authentication) &&
+                "Active Directory Default".Equals(authentication, StringComparison.OrdinalIgnoreCase) &&
+                connectionStringParameter.TryGetValue("AccountName", out var accountName))
+            {
+                if (!connectionStringParameter.TryGetValue("EndpointSuffix", out var endpointSuffix))
+                {
+                    endpointSuffix = "core.windows.net";
+                }
+
+                if (!connectionStringParameter.TryGetValue("DefaultEndpointsProtocol", out var endpointProtocol))
+                {
+                    endpointProtocol = "https";
+                }
+
+                var containerEndpoint = new Uri($"{endpointProtocol}://{accountName}.blob.{endpointSuffix}/{options.ContainerName}");
+                return new BlobContainerClient(containerEndpoint, new DefaultAzureCredential());
+            }
+            else
+            {
+                return new BlobContainerClient(options.ConnectionString, options.ContainerName);
+            }
+        }
+
+        /// <summary>
+        /// Gets the connection string parameters from the specified <paramref name="connectionString"/>.
+        /// </summary>
+        /// <param name="connectionString">The connection string.</param>
+        /// <returns>The connection string parameters.</returns>
+        private static IDictionary<string, string> GetConnectionStringParameters(string connectionString)
+            => ConnectionStringParser.Matches(connectionString ?? throw new ArgumentNullException(nameof(connectionString)))
+                                     .ToDictionary(
+                                        keySelector: match => match.Groups["Key"].Value.Trim(),
+                                        elementSelector: match => match.Groups["Value"].Value.Trim(),
+                                        comparer: StringComparer.OrdinalIgnoreCase);
+    }
+}

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/BlobContainerClientFactory.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/BlobContainerClientFactory.cs
@@ -19,7 +19,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
         /// <remarks>
         /// Unfortunatly the official parser is internal.
         /// </remarks>
-        private static readonly Regex ConnectionStringParser = new Regex("(?<Key>[^=]+)=(?<Value>[^;]+);?", RegexOptions.Compiled);
+        private static readonly Regex ConnectionStringParser = new Regex(@"\W*(?<Key>[^=]+)=(?<Value>[^;]+)", RegexOptions.Compiled);
 
         /// <inheritdoc/>
         public BlobContainerClient Build(AzureBlobFileSystemOptions options)

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/IBlobContainerClientFactory.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/IBlobContainerClientFactory.cs
@@ -1,0 +1,19 @@
+﻿using Azure.Storage.Blobs;
+
+namespace Umbraco.StorageProviders.AzureBlob.IO
+{
+    /// <summary>
+    /// The <see cref="BlobContainerClient"/> factory.
+    /// </summary>
+    public interface IBlobContainerClientFactory
+    {
+        /// <summary>
+        /// Builds a configured <see cref="BlobContainerClient" />.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <returns>
+        /// The configured <see cref="BlobContainerClient" />.
+        /// </returns>
+        BlobContainerClient Build(AzureBlobFileSystemOptions options);
+    }
+}

--- a/src/Umbraco.StorageProviders.AzureBlob/Imaging/AzureBlobFileSystemImageCache.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/Imaging/AzureBlobFileSystemImageCache.cs
@@ -23,31 +23,34 @@ namespace Umbraco.StorageProviders.AzureBlob.Imaging
         /// Initializes a new instance of the <see cref="AzureBlobFileSystemImageCache" /> class.
         /// </summary>
         /// <param name="options">The options.</param>
+        /// <param name="blobContainerClientFactory">The BLOB container client factory.</param>
         /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
-        public AzureBlobFileSystemImageCache(IOptionsMonitor<AzureBlobFileSystemOptions> options)
-            : this(AzureBlobFileSystemOptions.MediaFileSystemName, options)
+        public AzureBlobFileSystemImageCache(IOptionsMonitor<AzureBlobFileSystemOptions> options, IBlobContainerClientFactory blobContainerClientFactory)
+            : this(AzureBlobFileSystemOptions.MediaFileSystemName, options, blobContainerClientFactory)
         { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AzureBlobFileSystemImageCache"/> class.
+        /// Initializes a new instance of the <see cref="AzureBlobFileSystemImageCache" /> class.
         /// </summary>
         /// <param name="name">The name.</param>
         /// <param name="options">The options.</param>
+        /// <param name="blobContainerClientFactory">The BLOB container client factory.</param>
         /// <exception cref="System.ArgumentNullException"><paramref name="name" /> is <c>null</c>.</exception>
         /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
-        public AzureBlobFileSystemImageCache(string name, IOptionsMonitor<AzureBlobFileSystemOptions> options)
+        public AzureBlobFileSystemImageCache(string name, IOptionsMonitor<AzureBlobFileSystemOptions> options, IBlobContainerClientFactory blobContainerClientFactory)
         {
             ArgumentNullException.ThrowIfNull(name);
             ArgumentNullException.ThrowIfNull(options);
+            ArgumentNullException.ThrowIfNull(blobContainerClientFactory, paramName: nameof(blobContainerClientFactory));
 
             var fileSystemOptions = options.Get(name);
-            _container = new BlobContainerClient(fileSystemOptions.ConnectionString, fileSystemOptions.ContainerName);
+            _container = blobContainerClientFactory.Build(fileSystemOptions);
 
             options.OnChange((options, changedName) =>
             {
                 if (changedName == name)
                 {
-                    _container = new BlobContainerClient(options.ConnectionString, options.ContainerName);
+                    _container = blobContainerClientFactory.Build(fileSystemOptions);
                 }
             });
         }

--- a/src/Umbraco.StorageProviders.AzureBlob/packages.lock.json
+++ b/src/Umbraco.StorageProviders.AzureBlob/packages.lock.json
@@ -45,7 +45,7 @@
         "type": "Direct",
         "requested": "[10.0.0, 11.0.0)",
         "resolved": "10.0.0",
-        "contentHash": "VqKkYy9bB0hkdGuddZQdvtXwgy2jBbPDZFRjeCMWXN4pyyE+r8tPM9iWw+dQZ5abdmbmj+obITz5aTatiuRcEA==",
+        "contentHash": "4TlAMlFA+Nefr+57cG59lTDnK+7M1r+sHoRybj7A5k1ewzzghG0TnsW8StI5/nxnwuqis5h91G957ho27NLXFw==",
         "dependencies": {
           "Dazinator.Extensions.FileProviders": "2.0.0",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "6.0.5",
@@ -2216,7 +2216,7 @@
       "Umbraco.Cms.Core": {
         "type": "Transitive",
         "resolved": "10.0.0",
-        "contentHash": "PHu/jtyHUO/eJRv2L1uCRHyS3qeQZCGVe4IKzjuaCZtF6RZx0n5uZi4jvy4dx2J8YNC0pWFOE6JhhZkpt8O+gA==",
+        "contentHash": "KJ5BEiYNzc10gD8AeimnYKgXavB7kiT8I8Lcz0piqDUwj0DdJN6CQPibBuQ0MGkCmeIXeCPUEzumX72L/qxM6w==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
           "Microsoft.Extensions.FileProviders.Embedded": "6.0.5",
@@ -2235,7 +2235,7 @@
       "Umbraco.Cms.Examine.Lucene": {
         "type": "Transitive",
         "resolved": "10.0.0",
-        "contentHash": "4wbBOhrV5TFAuAAS/7CREyPEyVHlID9dvwIApbAKYadA+kOH9DtSSHAHhY47AOs4/6RfCwZlTTyWKr+xAddJEg==",
+        "contentHash": "v6AOYW0XyPiOvu0d4Ydzqxf46IRZrE6/e/kssrrXDHPKflT/la1YvRe7Cat/p/Ohi9ZjKXvKTpxyeB+qAhw+0Q==",
         "dependencies": {
           "Examine": "3.0.0",
           "Umbraco.Cms.Core": "10.0.0",
@@ -2245,7 +2245,7 @@
       "Umbraco.Cms.Infrastructure": {
         "type": "Transitive",
         "resolved": "10.0.0",
-        "contentHash": "aHgRLgc+2LL9VcSuJ1dv9gf8w3IQwTcTnxj+FDdg7fdpQR+BcINHfRh1ckVWt6+tuOuIikmk8RFvrutGo9fyAA==",
+        "contentHash": "SLWtTs9rQWUeA7zOt+zoZgLFkpEDXm+Cyr1rE7IMmX+6TsGiG4wIkVoZlvcY3e230wsGvG+AuIvzVPPz7kTMQA==",
         "dependencies": {
           "Examine.Core": "3.0.0",
           "HtmlAgilityPack": "1.11.43",
@@ -2285,7 +2285,7 @@
       "Umbraco.Cms.PublishedCache.NuCache": {
         "type": "Transitive",
         "resolved": "10.0.0",
-        "contentHash": "MtSBiyQW7Jpb91wlLyS5YqDWUhhoz/0ObEZ26xgkvACy3rQkgRbHVShi62pwmadJER3l9hkQpivpn6RlUfztFA==",
+        "contentHash": "STeqbhTumhL7YKDNE2LECXCohUrsXopVrNloyHnAySq6sNwJJV9aC1AbjiiUrWNNEV8CBOiFddFCGYMr99di+w==",
         "dependencies": {
           "CSharpTest.Net.Collections-NetStd2": "14.906.1403.1084",
           "K4os.Compression.LZ4": "1.2.16",

--- a/src/Umbraco.StorageProviders/packages.lock.json
+++ b/src/Umbraco.StorageProviders/packages.lock.json
@@ -25,7 +25,7 @@
         "type": "Direct",
         "requested": "[10.0.0, 11.0.0)",
         "resolved": "10.0.0",
-        "contentHash": "VqKkYy9bB0hkdGuddZQdvtXwgy2jBbPDZFRjeCMWXN4pyyE+r8tPM9iWw+dQZ5abdmbmj+obITz5aTatiuRcEA==",
+        "contentHash": "4TlAMlFA+Nefr+57cG59lTDnK+7M1r+sHoRybj7A5k1ewzzghG0TnsW8StI5/nxnwuqis5h91G957ho27NLXFw==",
         "dependencies": {
           "Dazinator.Extensions.FileProviders": "2.0.0",
           "Microsoft.AspNetCore.Mvc.NewtonsoftJson": "6.0.5",
@@ -2173,7 +2173,7 @@
       "Umbraco.Cms.Core": {
         "type": "Transitive",
         "resolved": "10.0.0",
-        "contentHash": "PHu/jtyHUO/eJRv2L1uCRHyS3qeQZCGVe4IKzjuaCZtF6RZx0n5uZi4jvy4dx2J8YNC0pWFOE6JhhZkpt8O+gA==",
+        "contentHash": "KJ5BEiYNzc10gD8AeimnYKgXavB7kiT8I8Lcz0piqDUwj0DdJN6CQPibBuQ0MGkCmeIXeCPUEzumX72L/qxM6w==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
           "Microsoft.Extensions.FileProviders.Embedded": "6.0.5",
@@ -2192,7 +2192,7 @@
       "Umbraco.Cms.Examine.Lucene": {
         "type": "Transitive",
         "resolved": "10.0.0",
-        "contentHash": "4wbBOhrV5TFAuAAS/7CREyPEyVHlID9dvwIApbAKYadA+kOH9DtSSHAHhY47AOs4/6RfCwZlTTyWKr+xAddJEg==",
+        "contentHash": "v6AOYW0XyPiOvu0d4Ydzqxf46IRZrE6/e/kssrrXDHPKflT/la1YvRe7Cat/p/Ohi9ZjKXvKTpxyeB+qAhw+0Q==",
         "dependencies": {
           "Examine": "3.0.0",
           "Umbraco.Cms.Core": "10.0.0",
@@ -2202,7 +2202,7 @@
       "Umbraco.Cms.Infrastructure": {
         "type": "Transitive",
         "resolved": "10.0.0",
-        "contentHash": "aHgRLgc+2LL9VcSuJ1dv9gf8w3IQwTcTnxj+FDdg7fdpQR+BcINHfRh1ckVWt6+tuOuIikmk8RFvrutGo9fyAA==",
+        "contentHash": "SLWtTs9rQWUeA7zOt+zoZgLFkpEDXm+Cyr1rE7IMmX+6TsGiG4wIkVoZlvcY3e230wsGvG+AuIvzVPPz7kTMQA==",
         "dependencies": {
           "Examine.Core": "3.0.0",
           "HtmlAgilityPack": "1.11.43",
@@ -2242,7 +2242,7 @@
       "Umbraco.Cms.PublishedCache.NuCache": {
         "type": "Transitive",
         "resolved": "10.0.0",
-        "contentHash": "MtSBiyQW7Jpb91wlLyS5YqDWUhhoz/0ObEZ26xgkvACy3rQkgRbHVShi62pwmadJER3l9hkQpivpn6RlUfztFA==",
+        "contentHash": "STeqbhTumhL7YKDNE2LECXCohUrsXopVrNloyHnAySq6sNwJJV9aC1AbjiiUrWNNEV8CBOiFddFCGYMr99di+w==",
         "dependencies": {
           "CSharpTest.Net.Collections-NetStd2": "14.906.1403.1084",
           "K4os.Compression.LZ4": "1.2.16",


### PR DESCRIPTION
I couldn't resist trying on my side 😉.

Here is my proposition :
To use managed identity, I replace all credentials in AzureStorage ConnectionString (configuration) with:
`Authentication=Active Directory Default`
This is the same usage as in the SQL Azure connection string.

If that parameter is there, I use the appropriate `BlobContainerClient` constructor. And in all other cases, I fall back on the current implementation.

As the constructor was called in multiple places, I created a factory to avoid code duplication and also to allow other developers to create their own implementation if needed.
 
Close #43 