### PR TITLE
Configure CDN as allowed media host

### DIFF
--- a/src/Umbraco.StorageProviders/DependencyInjection/CdnMediaUrlProviderExtensions.cs
+++ b/src/Umbraco.StorageProviders/DependencyInjection/CdnMediaUrlProviderExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Configuration.Models;
 using Umbraco.StorageProviders;
 
 namespace Umbraco.Cms.Core.DependencyInjection;
@@ -78,6 +79,16 @@ public static class CdnMediaUrlProviderExtensions
             .ValidateDataAnnotations();
 
         configure?.Invoke(optionsBuilder);
+
+        // Configure CDN as allowed media host
+        builder.Services.AddOptions<ContentSettings>().PostConfigure<IOptions<CdnMediaUrlProviderOptions>>((options, cdnMediaUrlProviderOptions) =>
+        {
+            string cdnMediaHost = cdnMediaUrlProviderOptions.Value.Url.Host;
+            if (!options.AllowedMediaHosts.Contains(cdnMediaHost, StringComparer.OrdinalIgnoreCase))
+            {
+                options.AllowedMediaHosts = [..options.AllowedMediaHosts, cdnMediaHost];
+            }
+        });
 
         return builder;
     }


### PR DESCRIPTION
Umbraco 10.5, 11.3 and higher added a new [`Umbraco:CMS:Content:AllowedMediaHosts`](https://docs.umbraco.com/umbraco-cms/reference/configuration/contentsettings#allowed-media-hosts) setting that restricts the allowed media URLs to specific hosts to prevent open redirects to untrusted hosts when generating a resized image for the backoffice (see PR https://github.com/umbraco/Umbraco-CMS/pull/13900).

To avoid the host of a configured CDN media URL not being allowed or having to add it manually, this PR automatically adds the CDN host (if it doesn't already exist) when calling `AddCdnMediaUrlProvider()`.

We can easily add support for this to v12 and the upcoming v13, because the setting exists in all versions of those majors. For v10 and v11, the CMS dependency would need to be updated to the minors that introduced it (removing compatibility for previous versions), which doesn't seem to be worth the effort. Instead, we can add an informational note that you need to manually configure this setting, so users are at least aware of it.