### PR TITLE
Updates to get and check "directories" that don't really exist in blob storage so they behave as would be expected for a file system.

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -129,6 +129,12 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     {
         ArgumentNullException.ThrowIfNull(path);
 
+        // If the path exists as a blob, it can't be a directory.
+        if (GetBlobClient(path).Exists())
+        {
+            return false;
+        }
+
         return ListBlobs(GetDirectoryPath(path)).Any();
     }
 


### PR DESCRIPTION
In investigating an issue with Forms where we download submitted files from the media system, I found this wasn't working on Cloud (using Azure blob storage for media), but was with a physical file system.

The issue looked to be calls to directory methods that didn't return expected results.

Directories don't really exist on a blob file system, but as these methods exist and are implemented on the interface, they should return expected results.

So this PR updates such that they should now do so.

They aren't the most efficient calls - it seems to check for a "directory" you can only list all the blobs that match the "directory as a prefix".  But at least they should now return expected results, and perhaps it'll have to be on the developer using them to have some understanding where these requests could be inefficient if they are using a blob file system.

To test I created a structure as follows:

```
media
  aaa
    bbb
      test.1jpg
    ccc
      test.2jpg
      test.3jpg
```

And tested with the following code placed into a view:

```
@inject Umbraco.Cms.Core.IO.MediaFileManager MediaFileManager;

@{
    var path1 = "aaa";
    var path2 = "aaa/bbb";
    var path3 = "aaa/bbb/test1.jpg";
    <div>Directory exists (@path1): @MediaFileManager.FileSystem.DirectoryExists(path1)</div>
    <div>Directory exists (@path2): @MediaFileManager.FileSystem.DirectoryExists(path2)</div>
    <div>Directory exists (@path3): @MediaFileManager.FileSystem.DirectoryExists(path3)</div>

    <div>Directories:</div>
    <ul>
        @foreach (string directory in MediaFileManager.FileSystem.GetDirectories(path1))
        {
            <li>
                <div>@directory</div>
                <div>Files:</div>
                <ul>
                        @foreach (string file in MediaFileManager.FileSystem.GetFiles(directory))
                        {
                            <li>@file</li>
                        }
                </ul>
            </li>
        }
    </ul>
}
```

And got the following expected output:

```
Directory exists (aaa): True
Directory exists (aaa/bbb): True
Directory exists (aaa/bbb/test1.jpg): False
Directories:
 - aaa/bbb
   Files:
        - aaa/bbb/test1.jpg
 - aaa/ccc
   Files:
        - aaa/ccc/test2.jpg
        - aaa/ccc/test3.jpg
 ```