### PR TITLE
Use directory delimiter when listing blobs

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -59,6 +53,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
         /// <exception cref="System.ArgumentNullException"><paramref name="blobContainerClient" /> is <c>null</c>.</exception>
         /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
         /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1054:URI-like parameters should not be strings", Justification = "This parameter is only a part of the URL.")]
         public AzureBlobFileSystem(string rootUrl, BlobContainerClient blobContainerClient, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider, string? containerRootPath = null)
         {
             ArgumentNullException.ThrowIfNull(rootUrl);
@@ -263,6 +258,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
 
         /// <inheritdoc />
         /// <exception cref="System.ArgumentNullException"><paramref name="fullPathOrUrl" /> is <c>null</c>.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1054:URI-like parameters should not be strings", Justification = "This method is inherited from an interface.")]
         public string GetRelativePath(string fullPathOrUrl)
         {
             ArgumentNullException.ThrowIfNull(fullPathOrUrl);
@@ -293,6 +289,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
 
         /// <inheritdoc />
         /// <exception cref="System.ArgumentNullException"><paramref name="path" /> is <c>null</c>.</exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1055:URI-like return values should not be strings", Justification = "This method is inherited from an interface.")]
         public string GetUrl(string? path)
         {
             ArgumentNullException.ThrowIfNull(path);

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -100,7 +100,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
 
             return ListBlobs(path)
                 .Where(x => x.IsPrefix)
-                .Select(x => GetRelativePath(x.Prefix).TrimEnd('/'));
+                .Select(x => GetRelativePath($"/{x.Prefix}").Trim('/'));
         }
 
         /// <inheritdoc />
@@ -231,7 +231,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
                 files = files.Where(x => x.IndexOf(filter, StringComparison.InvariantCultureIgnoreCase) > -1);
             }
 
-            return files.Select(GetRelativePath);
+            return files.Select(x => GetRelativePath($"/{x}"));
         }
 
         /// <inheritdoc />

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -128,7 +128,10 @@ namespace Umbraco.StorageProviders.AzureBlob.IO
         {
             ArgumentNullException.ThrowIfNull(path);
 
-            return ListBlobs(path).Any();
+            // Try getting a single item/page
+            Page<BlobHierarchyItem>? firstPage = ListBlobs(path).AsPages(pageSizeHint: 1).FirstOrDefault();
+
+            return firstPage?.Values.Count > 0;
         }
 
         /// <inheritdoc />

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "10.1.0-alpha",
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "10.0.1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
While reviewing PR https://github.com/umbraco/Umbraco.StorageProviders/pull/63 (targeting v13), I noticed the `IFileProvider` (an ASP.NET Core read-only file system abstraction) implementation already correctly retrieved the directories, because it specifies the delimiter that enables [traversing a virtual hierarchy of blobs as though it were a file system](https://learn.microsoft.com/en-us/dotnet/api/azure.storage.blobs.blobcontainerclient.getblobsbyhierarchy?view=azure-dotnet):

https://github.com/umbraco/Umbraco.StorageProviders/blob/aa5623b7b5f5c7d014847fa675b0679d8bf28118/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileProvider.cs#L53

This wasn't specified in the `IFileSystem` (the Umbraco read-write file system abstraction) implementation when listing blobs:

https://github.com/umbraco/Umbraco.StorageProviders/blob/93dc0596fb758fc9b685ca85551d9726535394a8/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs#L359

Without this delimiter, only blobs are returned that start with the specified prefix. This means the `GetDirectories()` didn't return anything (because none of the returned items were prefixes), `DirectoryExists()` always returned `false` (because a prefix is not a blob) and most notably, `GetFiles()` would return all blobs including the ones in 'subdirectories' (similar to using [`SearchOption.AllDirectories`](https://learn.microsoft.com/en-us/dotnet/api/system.io.searchoption?view=net-8.0)).

This PR fixes these issues and aligns the behavior between `IFileProvider` and `IFileSystem`. Testing can be done using the same instructions as the linked PR. Once reviewed and merged, this can be released as 10.0.1 and merged up to `support/12.0.x` (released as 12.0.1) and `develop` (released as 13.0.1).