### PR TITLE
Use options sepecific factory to create BlobContainerClient

### DIFF
--- a/examples/Umbraco.StorageProviders.AzureBlob.TestSite/AzureBlobFileSystemComposer.cs
+++ b/examples/Umbraco.StorageProviders.AzureBlob.TestSite/AzureBlobFileSystemComposer.cs
@@ -1,3 +1,5 @@
+using Azure.Core;
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Events;
@@ -8,10 +10,25 @@ namespace Umbraco.StorageProviders.AzureBlob.TestSite;
 
 internal sealed class AzureBlobFileSystemComposer : IComposer
 {
+    private static readonly BlobClientOptions _blobClientOptions = new BlobClientOptions
+    {
+        Retry = {
+            Mode = RetryMode.Exponential,
+            MaxRetries = 3
+        }
+    };
+
     public void Compose(IUmbracoBuilder builder)
         => builder
-        .AddAzureBlobMediaFileSystem()
+        // Add using default options (overly verbose, but shows how to revert back to the default)
+        .AddAzureBlobMediaFileSystem(options => options.CreateBlobContainerClientUsingDefault())
+        // Add using options
+        .AddAzureBlobMediaFileSystem(options => options.CreateBlobContainerClientUsingOptions(_blobClientOptions))
+        // If the connection string is parsed to a URI, use the delegate to create a BlobContainerClient
+        .AddAzureBlobMediaFileSystem(options => options.TryCreateBlobContainerClientUsingUri(uri => new BlobContainerClient(uri, _blobClientOptions)))
+        // Add the ImageSharp IImageCache implementation using the default media file system and "cache" container root path
         .AddAzureBlobImageSharpCache()
+        // Add notification handler to create the media file system on install if it doesn't exist
         .AddNotificationHandler<UnattendedInstallNotification, AzureBlobMediaFileSystemCreateIfNotExistsHandler>();
 
     private sealed class AzureBlobMediaFileSystemCreateIfNotExistsHandler : INotificationHandler<UnattendedInstallNotification>

--- a/src/Umbraco.StorageProviders.AzureBlob.ImageSharp/AzureBlobFileSystemImageCache.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob.ImageSharp/AzureBlobFileSystemImageCache.cs
@@ -31,14 +31,14 @@ public sealed class AzureBlobFileSystemImageCache : IImageCache
         ArgumentNullException.ThrowIfNull(name);
 
         AzureBlobFileSystemOptions fileSystemOptions = options.Get(name);
-        _container = new BlobContainerClient(fileSystemOptions.ConnectionString, fileSystemOptions.ContainerName);
+        _container = fileSystemOptions.CreateBlobContainerClient();
         _containerRootPath = GetContainerRootPath(containerRootPath, fileSystemOptions);
 
         options.OnChange((options, changedName) =>
         {
             if (changedName == name)
             {
-                _container = new BlobContainerClient(options.ConnectionString, options.ContainerName);
+                _container = options.CreateBlobContainerClient();
                 _containerRootPath = GetContainerRootPath(containerRootPath, options);
             }
         });

--- a/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileProvider.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileProvider.cs
@@ -40,7 +40,7 @@ public sealed class AzureBlobFileProvider : IFileProvider
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        _containerClient = new BlobContainerClient(options.ConnectionString, options.ContainerName);
+        _containerClient = options.CreateBlobContainerClient();
         _containerRootPath = options.ContainerRootPath?.Trim(Constants.CharArrays.ForwardSlash);
     }
 

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -30,7 +30,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
     public AzureBlobFileSystem(AzureBlobFileSystemOptions options, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider)
-        : this(GetRequestRootPath(options, hostingEnvironment), new BlobContainerClient(options.ConnectionString, options.ContainerName), ioHelper, contentTypeProvider, options.ContainerRootPath)
+        : this(GetRequestRootPath(options, hostingEnvironment), options.CreateBlobContainerClient(), ioHelper, contentTypeProvider, options.ContainerRootPath)
     { }
 
     /// <summary>
@@ -75,7 +75,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        return new BlobContainerClient(options.ConnectionString, options.ContainerName).CreateIfNotExists(accessType);
+        return options.CreateBlobContainerClient().CreateIfNotExists(accessType);
     }
 
     /// <inheritdoc />

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Azure.Storage.Blobs;
 
 namespace Umbraco.StorageProviders.AzureBlob.IO;
 
@@ -34,4 +35,20 @@ public sealed class AzureBlobFileSystemOptions
     /// </summary>
     [Required]
     public required string VirtualPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Azure Blob Container client factory.
+    /// </summary>
+    /// <value>
+    /// The Azure Blob Container client factory.
+    /// </value>
+    internal Func<AzureBlobFileSystemOptions, BlobContainerClient> BlobContainerClientFactory { get; set; } = DefaultBlobContainerClientFactory;
+
+    /// <summary>
+    /// Gets the default Azure Blob Container client factory.
+    /// </summary>
+    /// <value>
+    /// The default Azure Blob Container client factory.
+    /// </value>
+    internal static Func<AzureBlobFileSystemOptions, BlobContainerClient> DefaultBlobContainerClientFactory => options => new BlobContainerClient(options.ConnectionString, options.ContainerName);
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptionsExtensions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptionsExtensions.cs
@@ -1,0 +1,79 @@
+using Azure.Storage.Blobs;
+
+namespace Umbraco.StorageProviders.AzureBlob.IO;
+
+/// <summary>
+/// Extension methods for <see cref="AzureBlobFileSystemOptions" />.
+/// </summary>
+public static class AzureBlobFileSystemOptionsExtensions
+{
+    /// <summary>
+    /// Creates a <see cref="BlobContainerClient" /> using the default constructor accepting a connection string and container name.
+    /// </summary>
+    /// <param name="options">The Azure Blob File System options.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
+    public static void CreateBlobContainerClientUsingDefault(this AzureBlobFileSystemOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.BlobContainerClientFactory = AzureBlobFileSystemOptions.DefaultBlobContainerClientFactory;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="BlobContainerClient" /> using the default constructor accepting a connection string, container name and Blob client options.
+    /// </summary>
+    /// <param name="options">The Azure Blob File System options.</param>
+    /// <param name="blobClientOptions">The Azure Blob client options.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
+    public static void CreateBlobContainerClientUsingOptions(this AzureBlobFileSystemOptions options, BlobClientOptions blobClientOptions)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        options.BlobContainerClientFactory = options => new BlobContainerClient(options.ConnectionString, options.ContainerName, blobClientOptions);
+    }
+
+    /// <summary>
+    /// Parses the connection string to a URI and invokes the <paramref name="create" /> delegate to create a <see cref="BlobContainerClient" />.
+    /// </summary>
+    /// <param name="options">The Azure Blob File System options.</param>
+    /// <param name="create">The delegate to create a <see cref="BlobContainerClient" /> from the parsed <see cref="Uri" />.</param>
+    /// <remarks>
+    /// If the connection string can't be parsed to a URI, the existing delegate will be used instead.
+    /// </remarks>
+    /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
+    public static void TryCreateBlobContainerClientUsingUri(this AzureBlobFileSystemOptions options, Func<Uri, BlobContainerClient> create)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        Func<AzureBlobFileSystemOptions, BlobContainerClient> defaultCreate = options.BlobContainerClientFactory;
+        options.BlobContainerClientFactory = options =>
+        {
+            if (Uri.TryCreate(options.ConnectionString, UriKind.Absolute, out Uri? blobContainerUri))
+            {
+                var blobUriBuilder = new BlobUriBuilder(blobContainerUri)
+                {
+                    BlobContainerName = options.ContainerName
+                };
+
+                return create(blobUriBuilder.ToUri());
+            }
+
+            return defaultCreate(options);
+        };
+    }
+
+    /// <summary>
+    /// Creates the Azure Blob Container client using the configured factory.
+    /// </summary>
+    /// <param name="options">The Azure Blob File System options.</param>
+    /// <returns>
+    /// The Azure Blob Container client.
+    /// </returns>
+    /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
+    public static BlobContainerClient CreateBlobContainerClient(this AzureBlobFileSystemOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return options.BlobContainerClientFactory(options);
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/umbraco/Umbraco.StorageProviders/issues/43 by allowing users to customize the way the `BlobContainerClient` is created from the `AzureBlobFileSystemOptions` using:
- `AddAzureBlobMediaFileSystem(options => options.CreateBlobContainerClientUsingDefault())` - this is overly verbose to add by default, but allows users to reset any customizations back to the default factory (that uses the `ConnectionString` and `ContainerName`);
- `AddAzureBlobMediaFileSystem(options => options.CreateBlobContainerClientUsingOptions(_blobClientOptions))` - this is similar to the default factory, but uses custom a `BlobClientOptions` (allowing you to e.g. configure retry policies);
- `AddAzureBlobMediaFileSystem(options => options.TryCreateBlobContainerClientUsingUri(uri => new BlobContainerClient(uri, _blobClientOptions)))` - if the `ConnectionString` can be parsed into a valid URI, this factory will be used, otherwise it will fall back to the previous set/default one.

The `TryCreateBlobContainerClientUsingUri()` can be used to provide a `DefaultAzureCredential` instance (after adding the `Azure.Identity` package) to enable access using managed identities.