### PR TITLE
Align returned values with PhysicalFileSystem when blob does not exist

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
@@ -12,6 +13,10 @@ namespace Umbraco.StorageProviders.AzureBlob.IO;
 /// <inheritdoc />
 public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFactory
 {
+    // When not found, default to 1-1-1601 00:00:00 +00:00 for created/last modified and -1 for size to align with PhysicalFileSystem
+    private static readonly DateTimeOffset _notFoundDateTimeOffset = DateTimeOffset.FromUnixTimeSeconds(-11644473600);
+    private const long NotFoundSize = -1;
+
     private readonly string _requestRootPath;
     private readonly string _containerRootPath;
     private readonly BlobContainerClient _container;
@@ -91,6 +96,9 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
 
     /// <inheritdoc />
     /// <exception cref="System.ArgumentNullException"><paramref name="path" /> is <c>null</c>.</exception>
+    /// <remarks>
+    /// Azure Blob Storage can only delete blobs, so deleting directories is always recursive.
+    /// </remarks>
     public void DeleteDirectory(string path)
     {
         ArgumentNullException.ThrowIfNull(path);
@@ -100,6 +108,9 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
 
     /// <inheritdoc />
     /// <exception cref="System.ArgumentNullException"><paramref name="path" /> is <c>null</c>.</exception>
+    /// <remarks>
+    /// Azure Blob Storage can only delete blobs, so deleting directories is always recursive.
+    /// </remarks>
     public void DeleteDirectory(string path, bool recursive)
     {
         ArgumentNullException.ThrowIfNull(path);
@@ -303,7 +314,14 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     {
         ArgumentNullException.ThrowIfNull(path);
 
-        return GetBlobClient(path).GetProperties().Value.LastModified;
+        try
+        {
+            return GetBlobClient(path).GetProperties().Value.LastModified;
+        }
+        catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
+        {
+            return _notFoundDateTimeOffset;
+        }
     }
 
     /// <inheritdoc />
@@ -312,7 +330,14 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     {
         ArgumentNullException.ThrowIfNull(path);
 
-        return GetBlobClient(path).GetProperties().Value.CreatedOn;
+        try
+        {
+            return GetBlobClient(path).GetProperties().Value.CreatedOn;
+        }
+        catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
+        {
+            return _notFoundDateTimeOffset;
+        }
     }
 
     /// <inheritdoc />
@@ -321,7 +346,14 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     {
         ArgumentNullException.ThrowIfNull(path);
 
-        return GetBlobClient(path).GetProperties().Value.ContentLength;
+        try
+        {
+            return GetBlobClient(path).GetProperties().Value.ContentLength;
+        }
+        catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
+        {
+            return NotFoundSize;
+        }
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
This fixes https://github.com/umbraco/Umbraco.StorageProviders/issues/40 by catching the `RequestFailedException`, checking whether it was thrown because the blob doesn't exist and returning similar values as the default CMS `PhysicalFileSystem` does:
- `GetLastModified()` and `GetCreated()` return 1-1-1601 00:00:00 +00:00, as that's what [`FileSystemInfo.LastWriteTimeUtc`](https://learn.microsoft.com/en-us/dotnet/api/system.io.filesysteminfo.lastwritetimeutc?view=net-8.0#remarks) and [`FileSystemInfo.CreationTimeUtc`](https://learn.microsoft.com/en-us/dotnet/api/system.io.filesysteminfo.creationtimeutc?view=net-8.0#remarks) do;
- `GetSize()` returns -1, as that's what [`PhysicalFileSystem.GetSize()`](https://github.com/umbraco/Umbraco-CMS/blob/60a5b19dc9fe24f5379a253e1f3fdcb9cb537dfc/src/Umbraco.Core/IO/PhysicalFileSystem.cs#L408-L413) does.