### PR TITLE
Update to CMS 14.0.0-rc2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,16 +4,16 @@
   </PropertyGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
-    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <GlobalPackageReference Include="Umbraco.Code" Version="2.1.0" />
     <GlobalPackageReference Include="Umbraco.GitVersioning.Extensions" Version="0.2.0" />
   </ItemGroup>
   <PropertyGroup>
-    <UmbracoCmsPackageVersion>[13.0.0, 14)</UmbracoCmsPackageVersion>
+    <UmbracoCmsPackageVersion>[14.0.0-rc2, 15)</UmbracoCmsPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.19.1" />
-    <PackageVersion Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.1.0" />
+    <PackageVersion Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.1.2" />
     <PackageVersion Include="Umbraco.Cms.Imaging.ImageSharp" Version="$(UmbracoCmsPackageVersion)" />
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="$(UmbracoCmsPackageVersion)" />
   </ItemGroup>

--- a/examples/Directory.Build.props
+++ b/examples/Directory.Build.props
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <EnablePackageValidation>false</EnablePackageValidation>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 </Project>

--- a/examples/Umbraco.StorageProviders.AzureBlob.TestSite/.gitignore
+++ b/examples/Umbraco.StorageProviders.AzureBlob.TestSite/.gitignore
@@ -6,6 +6,9 @@
 appsettings-schema.json
 appsettings-schema.*.json
 
+# JSON schema file for umbraco-package.json
+umbraco-package-schema.json
+
 # Packages created from the backoffice (package.xml/package.zip)
 /umbraco/Data/CreatedPackages/
 

--- a/examples/Umbraco.StorageProviders.AzureBlob.TestSite/Program.cs
+++ b/examples/Umbraco.StorageProviders.AzureBlob.TestSite/Program.cs
@@ -19,7 +19,6 @@ app.UseUmbraco()
     })
     .WithEndpoints(u =>
     {
-        u.UseInstallerEndpoints();
         u.UseBackOfficeEndpoints();
         u.UseWebsiteEndpoints();
     });

--- a/examples/Umbraco.StorageProviders.AzureBlob.TestSite/Umbraco.StorageProviders.AzureBlob.TestSite.csproj
+++ b/examples/Umbraco.StorageProviders.AzureBlob.TestSite/Umbraco.StorageProviders.AzureBlob.TestSite.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms" Version="13.0.0" />
-    <PackageReference Include="Umbraco.TheStarterKit" Version="13.0.0-rc" />
+    <PackageReference Include="Umbraco.Cms" Version="14.0.0-rc2" />
+    <!--<PackageReference Include="Umbraco.TheStarterKit" Version="13.0.0" />-->
   </ItemGroup>
 
   <Import Project="..\..\src\Umbraco.StorageProviders\buildTransitive\Umbraco.StorageProviders.props" />

--- a/examples/Umbraco.StorageProviders.AzureBlob.TestSite/appsettings.json
+++ b/examples/Umbraco.StorageProviders.AzureBlob.TestSite/appsettings.json
@@ -11,7 +11,7 @@
     }
   },
   "ConnectionStrings": {
-    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco-13.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
+    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco-14.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
     "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
   },
   "Umbraco": {

--- a/src/Umbraco.StorageProviders/CdnMediaUrlProvider.cs
+++ b/src/Umbraco.StorageProviders/CdnMediaUrlProvider.cs
@@ -19,18 +19,16 @@ public sealed class CdnMediaUrlProvider : DefaultMediaUrlProvider
     private string _mediaPath;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CdnMediaUrlProvider"/> class.
+    /// Initializes a new instance of the <see cref="CdnMediaUrlProvider" /> class.
     /// </summary>
     /// <param name="options">The options.</param>
     /// <param name="globalSettings">The global settings.</param>
     /// <param name="hostingEnvironment">The hosting environment.</param>
     /// <param name="mediaPathGenerators">The media path generators.</param>
     /// <param name="uriUtility">The URI utility.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="options"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="globalSettings"/> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="hostingEnvironment"/> is <c>null</c>.</exception>
-    public CdnMediaUrlProvider(IOptionsMonitor<CdnMediaUrlProviderOptions> options, IOptionsMonitor<GlobalSettings> globalSettings, IHostingEnvironment hostingEnvironment, MediaUrlGeneratorCollection mediaPathGenerators, UriUtility uriUtility)
-        : base(mediaPathGenerators, uriUtility)
+    /// <param name="urlAssembler">The URL assembler.</param>
+    public CdnMediaUrlProvider(IOptionsMonitor<CdnMediaUrlProviderOptions> options, IOptionsMonitor<GlobalSettings> globalSettings, IHostingEnvironment hostingEnvironment, MediaUrlGeneratorCollection mediaPathGenerators, UriUtility uriUtility, IUrlAssembler urlAssembler)
+        : base(mediaPathGenerators, uriUtility, urlAssembler)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(globalSettings);

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "13.0.2-alpha",
+  "version": "14.0.0-rc1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
This updates the CMS dependency to 14.0.0-rc2, updates the `CdnMediaUrlProvider` constructor to avoid calling into an obsoleted base constructor and bumps the version to 14.0.0-rc1.