### PR TITLE
Another take on BlobContainerClient / managed identity - resolve from DI

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob.ImageSharp/DependencyInjection/AddAzureBlobImageSharpCacheExtensions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob.ImageSharp/DependencyInjection/AddAzureBlobImageSharpCacheExtensions.cs
@@ -1,5 +1,5 @@
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using SixLabors.ImageSharp.Web.Caching;
 using Umbraco.Extensions;
 using Umbraco.StorageProviders.AzureBlob.ImageSharp;
@@ -52,7 +52,7 @@ public static class AddAzureBlobImageSharpCacheExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
 
-        builder.Services.AddUnique<IImageCache>(provider => new AzureBlobFileSystemImageCache(provider.GetRequiredService<IOptionsMonitor<AzureBlobFileSystemOptions>>(), name, containerRootPath));
+        builder.Services.AddUnique<IImageCache>(provider => new AzureBlobFileSystemImageCache(provider.GetRequiredService<BlobContainerClient>(), containerRootPath));
 
         return builder;
     }

--- a/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobFileSystemExtensions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobFileSystemExtensions.cs
@@ -101,7 +101,7 @@ public static class AzureBlobFileSystemExtensions
     /// <summary>
     /// Returns the configuration key for the Azure Blob Storage file system.
     /// </summary>
-    /// <param name="name">The specific AzureBlob configuration key name</param>
-    /// <returns>A <see cref="string"/>with the configuration key </returns>
+    /// <param name="name">The specific AzureBlob configuration key name.</param>
+    /// <returns>A <see cref="string"/>with the configuration key.</returns>
     internal static string UmbracoStorageAzureBlobMediaConfigurationKey(string name = AzureBlobFileSystemOptions.MediaFileSystemName) => $"Umbraco:Storage:AzureBlob:{name}";
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobFileSystemExtensions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobFileSystemExtensions.cs
@@ -90,11 +90,18 @@ public static class AzureBlobFileSystemExtensions
         builder.Services.TryAddSingleton<IAzureBlobFileSystemProvider, AzureBlobFileSystemProvider>();
 
         OptionsBuilder<AzureBlobFileSystemOptions> optionsBuilder = builder.Services.AddOptions<AzureBlobFileSystemOptions>(name)
-            .BindConfiguration($"Umbraco:Storage:AzureBlob:{name}")
+            .BindConfiguration(UmbracoStorageAzureBlobMediaConfigurationKey(name))
             .ValidateDataAnnotations();
 
         configure?.Invoke(optionsBuilder);
 
         return builder;
     }
+
+    /// <summary>
+    /// Returns the configuration key for the Azure Blob Storage file system.
+    /// </summary>
+    /// <param name="name">The specific AzureBlob configuration key name</param>
+    /// <returns>A <see cref="string"/>with the configuration key </returns>
+    internal static string UmbracoStorageAzureBlobMediaConfigurationKey(string name = AzureBlobFileSystemOptions.MediaFileSystemName) => $"Umbraco:Storage:AzureBlob:{name}";
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobMediaFileSystemExtensions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/DependencyInjection/AzureBlobMediaFileSystemExtensions.cs
@@ -75,7 +75,7 @@ public static class AzureBlobMediaFileSystemExtensions
             .Get<AzureBlobFileSystemOptions>() ?? throw new InvalidOperationException($"Configuration section Umbraco:Storage:AzureBlob:{AzureBlobFileSystemOptions.MediaFileSystemName} must have a value");
 
         // Register the BlobContainerClient as a scoped service. Uses the `Try` method, so if there is a previously registered service, it will not be replaced.
-        builder.Services.TryAddScoped(_ => new BlobContainerClient(config.ConnectionString, config.ContainerName));
+        builder.Services.TryAddSingleton(_ => new BlobContainerClient(config.ConnectionString, config.ContainerName));
 
         builder.SetMediaFileSystem(provider => provider.GetRequiredService<IAzureBlobFileSystemProvider>().GetFileSystem(AzureBlobFileSystemOptions.MediaFileSystemName));
 

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -22,6 +22,23 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class.
     /// </summary>
     /// <param name="options">The Azure Blob File System options.</param>
+    /// <param name="blobContainerClient">The blob container client.</param>
+    /// <param name="hostingEnvironment">The hosting environment.</param>
+    /// <param name="ioHelper">The I/O helper.</param>
+    /// <param name="contentTypeProvider">The content type provider.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="hostingEnvironment" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="blobContainerClient" /> is <c>null</c>.</exception>
+    public AzureBlobFileSystem(AzureBlobFileSystemOptions options, BlobContainerClient blobContainerClient, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider)
+        : this(GetRequestRootPath(options, hostingEnvironment), blobContainerClient, ioHelper, contentTypeProvider, options.ContainerRootPath)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class.
+    /// </summary>
+    /// <param name="options">The Azure Blob File System options.</param>
     /// <param name="hostingEnvironment">The hosting environment.</param>
     /// <param name="ioHelper">The I/O helper.</param>
     /// <param name="contentTypeProvider">The content type provider.</param>
@@ -45,6 +62,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// <exception cref="System.ArgumentNullException"><paramref name="blobContainerClient" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="blobContainerClient" /> is <c>null</c>.</exception>
     public AzureBlobFileSystem(string requestRootPath, BlobContainerClient blobContainerClient, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider, string? containerRootPath = null)
     {
         ArgumentNullException.ThrowIfNull(requestRootPath);

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -104,7 +104,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     {
         ArgumentNullException.ThrowIfNull(path);
 
-        foreach (BlobHierarchyItem blob in ListBlobs(path, true))
+        foreach (BlobHierarchyItem blob in ListBlobs(path, recursive))
         {
             if (blob.IsBlob)
             {

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemProvider.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemProvider.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
+using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
@@ -13,6 +15,8 @@ public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider
     private readonly IOptionsMonitor<AzureBlobFileSystemOptions> _optionsMonitor;
     private readonly IHostingEnvironment _hostingEnvironment;
     private readonly IIOHelper _ioHelper;
+    private readonly IServiceProvider _provider;
+
     private readonly FileExtensionContentTypeProvider _fileExtensionContentTypeProvider;
 
     /// <summary>
@@ -21,14 +25,17 @@ public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider
     /// <param name="optionsMonitor">The options monitor.</param>
     /// <param name="hostingEnvironment">The hosting environment.</param>
     /// <param name="ioHelper">The IO helper.</param>
+    /// <param name="provider">The .</param>
     /// <exception cref="ArgumentNullException"><paramref name="optionsMonitor"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="hostingEnvironment"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="ioHelper"/> is <c>null</c>.</exception>
-    public AzureBlobFileSystemProvider(IOptionsMonitor<AzureBlobFileSystemOptions> optionsMonitor, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper)
+    /// <exception cref="ArgumentNullException"><paramref name="provider"/> is <c>null</c>.</exception>
+    public AzureBlobFileSystemProvider(IOptionsMonitor<AzureBlobFileSystemOptions> optionsMonitor, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper, IServiceProvider provider)
     {
         _optionsMonitor = optionsMonitor ?? throw new ArgumentNullException(nameof(optionsMonitor));
         _hostingEnvironment = hostingEnvironment ?? throw new ArgumentNullException(nameof(hostingEnvironment));
         _ioHelper = ioHelper ?? throw new ArgumentNullException(nameof(ioHelper));
+        _provider = provider;
         _fileExtensionContentTypeProvider = new FileExtensionContentTypeProvider();
 
         _optionsMonitor.OnChange((options, name) => _fileSystems.TryRemove(name ?? Options.DefaultName, out _));
@@ -44,7 +51,10 @@ public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider
         {
             AzureBlobFileSystemOptions options = _optionsMonitor.Get(name);
 
-            return new AzureBlobFileSystem(options, _hostingEnvironment, _ioHelper, _fileExtensionContentTypeProvider);
+            using IServiceScope scope = _provider.CreateScope();
+            BlobContainerClient blobContainerClient = scope.ServiceProvider.GetRequiredService<BlobContainerClient>();
+
+            return new AzureBlobFileSystem(options, blobContainerClient, _hostingEnvironment, _ioHelper, _fileExtensionContentTypeProvider);
         });
     }
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemProvider.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemProvider.cs
@@ -25,7 +25,7 @@ public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider
     /// <param name="optionsMonitor">The options monitor.</param>
     /// <param name="hostingEnvironment">The hosting environment.</param>
     /// <param name="ioHelper">The IO helper.</param>
-    /// <param name="provider">The .</param>
+    /// <param name="provider">The <see cref="IServiceProvider"/> used to instantiate a <see cref="BlobContainerClient"/>.</param>
     /// <exception cref="ArgumentNullException"><paramref name="optionsMonitor"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="hostingEnvironment"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="ioHelper"/> is <c>null</c>.</exception>


### PR DESCRIPTION
This resolves #43 by allowing consumers to register their own `BlobServiceClient` with DI, and then these Storage providers will then use that version. They can then use the Azure SDKs / AzureIdentity libs as necessary.

Falls back to creating a `BlobServiceClient` with the default settings if one has not been previously registered. Basically as it worked before.

Where applicable, I've tried to implement this by adding additional overloads, so anyone depending on the old behaviour should still be good.

The DI extension methods do defer to the new versions however.



