### PR TITLE
Make sure stream position is set to zero

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -167,6 +167,11 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
             headers.ContentType = contentType;
         }
 
+        if (stream.CanSeek)
+        {
+            stream.Seek(0, 0);
+        }
+
         BlobRequestConditions? conditions = overrideIfExists ? null : new BlobRequestConditions
         {
             IfNoneMatch = ETag.All


### PR DESCRIPTION
I ran into an issue in Umbraco Cloud where a file operation was working fine locally but not when pushed to Cloud. Looking into the logs Azure threw an exception:
**System.ArgumentException: content.Position must be less than content.Length. Please set content.Position to the start of the data to upload.**

The problem was obviously the position of the stream i was trying to write, but the same code was working just fine locally, so i guessed this was being handled by the PhysicalFileProvider and looking into it this turned out to be the case. So to stream line this behaviour it makes sense for the Azure Storage Provider to do the same (see: https://github.com/umbraco/Umbraco-CMS/blob/v14/dev/src/Umbraco.Core/IO/PhysicalFileSystem.cs#L182C1-L185C14)