### PR TITLE
Add in-memory cache for blob metadata in file provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,55 @@ UMBRACO__STORAGE__AZUREBLOB__MEDIA__CONTAINERNAME=sample-container
 > **Note**
 > You still have to add the provider in the `Program.cs` file when not configuring the options in code.
 
+### Blob metadata caching
+The read-only file provider serving media performs a synchronous metadata lookup (`GetProperties()`) against Azure Blob Storage on every request. Under load the default Azure SDK retry policy can hold a thread for many seconds per call, so the provider caches blob metadata (size and last modified) in-memory per blob path to avoid the round-trip on the steady-state hot path, reducing both latency and thread-pool pressure.
+
+Writes through the file system (`AddFile`/`DeleteFile`/`DeleteDirectory`) invalidate the affected cache entries immediately, so only writes performed outside this instance (another process, another instance, or directly via the Azure SDK) can leave metadata stale for up to the configured hit duration.
+
+Caching is enabled by default. It can be configured in code:
+```csharp
+.AddAzureBlobMediaFileSystem(options => {
+    options.Cache.Enabled = true;
+    options.Cache.HitDuration = TimeSpan.FromSeconds(30);
+    options.Cache.MissDuration = TimeSpan.FromSeconds(5);
+    options.Cache.SizeLimit = 10_000;
+})
+```
+
+In `appsettings.json` (durations use the `hh:mm:ss` format):
+```json
+{
+  "Umbraco": {
+    "Storage": {
+      "AzureBlob": {
+        "Media": {
+          "Cache": {
+            "Enabled": true,
+            "HitDuration": "00:00:30",
+            "MissDuration": "00:00:05",
+            "SizeLimit": 10000
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Or by environment variables:
+```sh
+UMBRACO__STORAGE__AZUREBLOB__MEDIA__CACHE__ENABLED=true
+UMBRACO__STORAGE__AZUREBLOB__MEDIA__CACHE__HITDURATION=00:00:30
+UMBRACO__STORAGE__AZUREBLOB__MEDIA__CACHE__MISSDURATION=00:00:05
+UMBRACO__STORAGE__AZUREBLOB__MEDIA__CACHE__SIZELIMIT=10000
+```
+
+The available options are:
+- `Enabled` - whether blob metadata caching is enabled (default `true`).
+- `HitDuration` - how long a successful metadata lookup is cached (default 30 seconds).
+- `MissDuration` - how long a not-found result is cached; kept shorter than `HitDuration` so newly-uploaded blobs become visible quickly (default 5 seconds).
+- `SizeLimit` - the maximum number of cached entries, each counting as a single unit (default 10,000).
+
 ### Custom blob container options
 To override the default blob container options, you can use the following extension methods on `AzureBlobFileSystemOptions`:
 ```csharp

--- a/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileProvider.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileProvider.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 using Umbraco.Cms.Core;
@@ -18,6 +20,8 @@ public sealed class AzureBlobFileProvider : IFileProvider
 {
     private readonly BlobContainerClient _containerClient;
     private readonly string? _containerRootPath;
+    private readonly IMemoryCache? _cache;
+    private readonly AzureBlobFileSystemCacheOptions? _cacheOptions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureBlobFileProvider" /> class.
@@ -32,17 +36,43 @@ public sealed class AzureBlobFileProvider : IFileProvider
     }
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="AzureBlobFileProvider" /> class with blob metadata caching backed by a caller-supplied <see cref="IMemoryCache" />.
+    /// </summary>
+    /// <param name="containerClient">The container client.</param>
+    /// <param name="containerRootPath">The container root path.</param>
+    /// <param name="cache">The cache used to store blob metadata. The lifetime of this cache is owned by the caller.</param>
+    /// <param name="cacheOptions">The cache options supplying the absolute expirations for found and not-found entries.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="containerClient" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="cache" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="cacheOptions" /> is <c>null</c>.</exception>
+    public AzureBlobFileProvider(BlobContainerClient containerClient, string? containerRootPath, IMemoryCache cache, AzureBlobFileSystemCacheOptions cacheOptions)
+        : this(containerClient, containerRootPath)
+    {
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _cacheOptions = cacheOptions ?? throw new ArgumentNullException(nameof(cacheOptions));
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="AzureBlobFileProvider" /> class.
     /// </summary>
     /// <param name="options">The options.</param>
     /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
     public AzureBlobFileProvider(AzureBlobFileSystemOptions options)
-    {
-        ArgumentNullException.ThrowIfNull(options);
+        : this(GetContainerClient(options), options.ContainerRootPath)
+    { }
 
-        _containerClient = options.CreateBlobContainerClient();
-        _containerRootPath = options.ContainerRootPath?.Trim(Constants.CharArrays.ForwardSlash);
-    }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureBlobFileProvider" /> class with blob metadata caching backed by a caller-supplied <see cref="IMemoryCache" />.
+    /// </summary>
+    /// <param name="options">The options.</param>
+    /// <param name="cache">The cache used to store blob metadata. The lifetime of this cache is owned by the caller.</param>
+    /// <param name="cacheOptions">The cache options supplying the absolute expirations for found and not-found entries.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="cache" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="cacheOptions" /> is <c>null</c>.</exception>
+    public AzureBlobFileProvider(AzureBlobFileSystemOptions options, IMemoryCache cache, AzureBlobFileSystemCacheOptions cacheOptions)
+        : this(GetContainerClient(options), options.ContainerRootPath, cache, cacheOptions)
+    { }
 
     /// <inheritdoc />
     public IDirectoryContents GetDirectoryContents(string subpath)
@@ -61,23 +91,83 @@ public sealed class AzureBlobFileProvider : IFileProvider
     public IFileInfo GetFileInfo(string subpath)
     {
         var path = GetFullPath(subpath);
+
+        if (TryGetFromCache(path, out IFileInfo? cached))
+        {
+            return cached;
+        }
+
         BlobClient blobClient = _containerClient.GetBlobClient(path);
 
-        BlobProperties properties;
+        IFileInfo fileInfo;
+        bool found;
         try
         {
-            properties = blobClient.GetProperties().Value;
+            BlobProperties properties = blobClient.GetProperties().Value;
+            fileInfo = new AzureBlobItemInfo(blobClient, properties);
+            found = true;
         }
         catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
         {
-            return new NotFoundFileInfo(AzureBlobItemInfo.ParseName(path));
+            fileInfo = new NotFoundFileInfo(AzureBlobItemInfo.ParseName(path));
+            found = false;
         }
 
-        return new AzureBlobItemInfo(blobClient, properties);
+        TrySetCache(path, fileInfo, found);
+
+        return fileInfo;
     }
 
     /// <inheritdoc />
     public IChangeToken Watch(string filter) => NullChangeToken.Singleton;
 
     private string GetFullPath(string subpath) => _containerRootPath + subpath.EnsureStartsWith('/');
+
+    private bool TryGetFromCache(string path, [NotNullWhen(true)] out IFileInfo? value)
+    {
+        if (_cache is null)
+        {
+            value = null;
+            return false;
+        }
+
+        try
+        {
+            return _cache.TryGetValue(path, out value) && value is not null;
+        }
+        catch (ObjectDisposedException)
+        {
+            // Cache was disposed mid-request (options change or app shutdown); fall through to fetch from blob.
+            value = null;
+            return false;
+        }
+    }
+
+    private void TrySetCache(string path, IFileInfo fileInfo, bool found)
+    {
+        if (_cache is null || _cacheOptions is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _cache.Set(path, fileInfo, new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = found ? _cacheOptions.HitDuration : _cacheOptions.MissDuration,
+                Size = 1,
+            });
+        }
+        catch (ObjectDisposedException)
+        {
+            // Cache was disposed mid-request (options change or app shutdown); skip caching this entry.
+        }
+    }
+
+    private static BlobContainerClient GetContainerClient(AzureBlobFileSystemOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return options.CreateBlobContainerClient();
+    }
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -146,7 +146,14 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
         {
             if (blob.IsBlob)
             {
-                _container.GetBlobClient(blob.Blob.Name).DeleteIfExists();
+                try
+                {
+                    _container.GetBlobClient(blob.Blob.Name).DeleteIfExists();
+                }
+                finally
+                {
+                    InvalidateCacheEntry(blob.Blob.Name);
+                }
             }
         }
     }
@@ -199,11 +206,18 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
             IfNoneMatch = ETag.All
         };
 
-        blob.Upload(stream, new BlobUploadOptions()
+        try
         {
-            HttpHeaders = headers,
-            Conditions = conditions
-        });
+            blob.Upload(stream, new BlobUploadOptions()
+            {
+                HttpHeaders = headers,
+                Conditions = conditions
+            });
+        }
+        finally
+        {
+            InvalidateCacheEntry(blob.Name);
+        }
     }
 
     /// <inheritdoc />
@@ -226,19 +240,30 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
             IfNoneMatch = ETag.All
         };
 
-        CopyFromUriOperation copyFromUriOperation = destinationBlob.StartCopyFromUri(sourceBlob.Uri, new BlobCopyFromUriOptions()
+        try
         {
-            DestinationConditions = destinationConditions
-        });
+            CopyFromUriOperation copyFromUriOperation = destinationBlob.StartCopyFromUri(sourceBlob.Uri, new BlobCopyFromUriOptions()
+            {
+                DestinationConditions = destinationConditions
+            });
 
-        if (copyFromUriOperation?.HasCompleted == false)
-        {
-            copyFromUriOperation.WaitForCompletion();
+            if (copyFromUriOperation?.HasCompleted == false)
+            {
+                copyFromUriOperation.WaitForCompletion();
+            }
+
+            if (!copy)
+            {
+                sourceBlob.DeleteIfExists();
+            }
         }
-
-        if (!copy)
+        finally
         {
-            sourceBlob.DeleteIfExists();
+            InvalidateCacheEntry(destinationBlob.Name);
+            if (!copy)
+            {
+                InvalidateCacheEntry(sourceBlob.Name);
+            }
         }
     }
 
@@ -283,7 +308,15 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     {
         ArgumentNullException.ThrowIfNull(path);
 
-        GetBlobClient(path).DeleteIfExists();
+        BlobClient blob = GetBlobClient(path);
+        try
+        {
+            blob.DeleteIfExists();
+        }
+        finally
+        {
+            InvalidateCacheEntry(blob.Name);
+        }
     }
 
     /// <inheritdoc />
@@ -399,6 +432,23 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
 
     /// <inheritdoc />
     public void Dispose() => _cache?.Dispose();
+
+    private void InvalidateCacheEntry(string blobName)
+    {
+        if (_cache is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _cache.Remove(blobName);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Cache was disposed during the call (options change or app shutdown); nothing to invalidate.
+        }
+    }
 
     private static string GetRequestRootPath(AzureBlobFileSystemOptions options, IHostingEnvironment hostingEnvironment)
     {

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -3,6 +3,7 @@ using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.FileProviders;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
@@ -11,7 +12,7 @@ using Umbraco.Extensions;
 namespace Umbraco.StorageProviders.AzureBlob.IO;
 
 /// <inheritdoc />
-public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFactory
+public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFactory, IDisposable
 {
     // When not found, default to 1-1-1601 00:00:00 +00:00 for created/last modified and -1 for size to align with PhysicalFileSystem
     private static readonly DateTimeOffset _notFoundDateTimeOffset = DateTimeOffset.FromUnixTimeSeconds(-11644473600);
@@ -22,6 +23,8 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     private readonly BlobContainerClient _container;
     private readonly IIOHelper _ioHelper;
     private readonly IContentTypeProvider _contentTypeProvider;
+    private readonly MemoryCache? _cache;
+    private readonly AzureBlobFileSystemCacheOptions? _cacheOptions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class.
@@ -35,7 +38,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
     public AzureBlobFileSystem(AzureBlobFileSystemOptions options, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider)
-        : this(GetRequestRootPath(options, hostingEnvironment), options.CreateBlobContainerClient(), ioHelper, contentTypeProvider, options.ContainerRootPath)
+        : this(GetRequestRootPath(options, hostingEnvironment), options.CreateBlobContainerClient(), ioHelper, contentTypeProvider, options.ContainerRootPath, options.Cache)
     { }
 
     /// <summary>
@@ -50,7 +53,25 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// <exception cref="System.ArgumentNullException"><paramref name="blobContainerClient" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
+    [Obsolete("Use the overload that accepts an AzureBlobFileSystemCacheOptions to enable blob metadata caching.")]
     public AzureBlobFileSystem(string requestRootPath, BlobContainerClient blobContainerClient, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider, string? containerRootPath = null)
+        : this(requestRootPath, blobContainerClient, ioHelper, contentTypeProvider, containerRootPath, cacheOptions: null)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class.
+    /// </summary>
+    /// <param name="requestRootPath">The request/URL root path.</param>
+    /// <param name="blobContainerClient">The blob container client.</param>
+    /// <param name="ioHelper">The I/O helper.</param>
+    /// <param name="contentTypeProvider">The content type provider.</param>
+    /// <param name="containerRootPath">The container root path (uses the request/URL root path if not set).</param>
+    /// <param name="cacheOptions">The blob metadata cache options applied to the read-only file provider. When <c>null</c>, caching is disabled.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="requestRootPath" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="blobContainerClient" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
+    public AzureBlobFileSystem(string requestRootPath, BlobContainerClient blobContainerClient, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider, string? containerRootPath, AzureBlobFileSystemCacheOptions? cacheOptions)
     {
         ArgumentNullException.ThrowIfNull(requestRootPath);
 
@@ -59,6 +80,12 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
         _container = blobContainerClient ?? throw new ArgumentNullException(nameof(blobContainerClient));
         _ioHelper = ioHelper ?? throw new ArgumentNullException(nameof(ioHelper));
         _contentTypeProvider = contentTypeProvider ?? throw new ArgumentNullException(nameof(contentTypeProvider));
+
+        if (cacheOptions?.Enabled == true)
+        {
+            _cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = cacheOptions.SizeLimit });
+            _cacheOptions = cacheOptions;
+        }
     }
 
     /// <inheritdoc />
@@ -366,7 +393,12 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     }
 
     /// <inheritdoc />
-    public IFileProvider Create() => new AzureBlobFileProvider(_container, _containerRootPath);
+    public IFileProvider Create() => _cache is null || _cacheOptions is null
+        ? new AzureBlobFileProvider(_container, _containerRootPath)
+        : new AzureBlobFileProvider(_container, _containerRootPath, _cache, _cacheOptions);
+
+    /// <inheritdoc />
+    public void Dispose() => _cache?.Dispose();
 
     private static string GetRequestRootPath(AzureBlobFileSystemOptions options, IHostingEnvironment hostingEnvironment)
     {

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemCacheOptions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemCacheOptions.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.FileProviders;
+
+namespace Umbraco.StorageProviders.AzureBlob.IO;
+
+/// <summary>
+/// In-memory cache settings applied to blob metadata lookups performed by the read-only file provider.
+/// </summary>
+/// <remarks>
+/// Caching blob metadata (size, last modified, content type) avoids a network round-trip to Azure Blob Storage
+/// on every media request. Under load the default Azure SDK retry policy can hold a thread for many seconds
+/// per call, so eliminating the round-trip for the steady-state hot path significantly reduces both latency
+/// and thread-pool pressure. Metadata is cached per blob path with a short absolute expiration.
+/// </remarks>
+public sealed class AzureBlobFileSystemCacheOptions : IValidatableObject
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether blob metadata caching is enabled.
+    /// </summary>
+    /// <value>
+    /// <c>true</c> if caching is enabled; otherwise, <c>false</c>.
+    /// </value>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets how long a successful metadata lookup is cached.
+    /// </summary>
+    /// <value>
+    /// The cache duration for found blobs.
+    /// </value>
+    /// <remarks>
+    /// Same-process writes to a blob will see stale metadata for up to this duration. Defaults to 30 seconds.
+    /// </remarks>
+    public TimeSpan HitDuration { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets how long a not-found metadata result is cached.
+    /// </summary>
+    /// <value>
+    /// The cache duration for not-found blobs.
+    /// </value>
+    /// <remarks>
+    /// Kept shorter than <see cref="HitDuration" /> so newly-uploaded blobs become visible quickly.
+    /// Defaults to 5 seconds.
+    /// </remarks>
+    public TimeSpan MissDuration { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets or sets the maximum number of cached <see cref="IFileInfo" /> entries.
+    /// </summary>
+    /// <value>
+    /// The cache size limit.
+    /// </value>
+    /// <remarks>
+    /// Each cache entry counts as a single unit. Defaults to 10,000 entries.
+    /// </remarks>
+    public long SizeLimit { get; set; } = 10_000;
+
+    /// <inheritdoc />
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (HitDuration <= TimeSpan.Zero)
+        {
+            yield return new ValidationResult($"{nameof(HitDuration)} must be a positive duration; got {HitDuration}.", [nameof(HitDuration)]);
+        }
+
+        if (MissDuration <= TimeSpan.Zero)
+        {
+            yield return new ValidationResult($"{nameof(MissDuration)} must be a positive duration; got {MissDuration}.", [nameof(MissDuration)]);
+        }
+
+        if (SizeLimit < 0)
+        {
+            yield return new ValidationResult($"{nameof(SizeLimit)} must be a non-negative integer; got {SizeLimit}.", [nameof(SizeLimit)]);
+        }
+    }
+}

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemCacheOptions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemCacheOptions.cs
@@ -7,7 +7,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO;
 /// In-memory cache settings applied to blob metadata lookups performed by the read-only file provider.
 /// </summary>
 /// <remarks>
-/// Caching blob metadata (size, last modified, content type) avoids a network round-trip to Azure Blob Storage
+/// Caching blob metadata (size, last modified) avoids a network round-trip to Azure Blob Storage
 /// on every media request. Under load the default Azure SDK retry policy can hold a thread for many seconds
 /// per call, so eliminating the round-trip for the steady-state hot path significantly reduces both latency
 /// and thread-pool pressure. Metadata is cached per blob path with a short absolute expiration.
@@ -29,7 +29,10 @@ public sealed class AzureBlobFileSystemCacheOptions : IValidatableObject
     /// The cache duration for found blobs.
     /// </value>
     /// <remarks>
-    /// Same-process writes to a blob will see stale metadata for up to this duration. Defaults to 30 seconds.
+    /// Writes through this filesystem instance (<see cref="AzureBlobFileSystem.AddFile(string, System.IO.Stream)" />,
+    /// <see cref="AzureBlobFileSystem.DeleteFile(string)" />, <see cref="AzureBlobFileSystem.DeleteDirectory(string)" />)
+    /// invalidate the affected cache entries immediately. Only writes performed outside this instance (another process,
+    /// another instance, or directly via the Azure SDK) can leave metadata stale for up to this duration. Defaults to 30 seconds.
     /// </remarks>
     public TimeSpan HitDuration { get; set; } = TimeSpan.FromSeconds(30);
 

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptions.cs
@@ -6,7 +6,7 @@ namespace Umbraco.StorageProviders.AzureBlob.IO;
 /// <summary>
 /// The Azure Blob File System options.
 /// </summary>
-public sealed class AzureBlobFileSystemOptions
+public sealed class AzureBlobFileSystemOptions : IValidatableObject
 {
     /// <summary>
     /// The media filesystem name.
@@ -37,6 +37,14 @@ public sealed class AzureBlobFileSystemOptions
     public required string VirtualPath { get; set; }
 
     /// <summary>
+    /// Gets or sets the in-memory cache settings applied to blob metadata lookups by the read-only file provider.
+    /// </summary>
+    /// <value>
+    /// The in-memory cache settings.
+    /// </value>
+    public AzureBlobFileSystemCacheOptions Cache { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the Azure Blob Container client factory.
     /// </summary>
     /// <value>
@@ -51,4 +59,26 @@ public sealed class AzureBlobFileSystemOptions
     /// The default Azure Blob Container client factory.
     /// </value>
     internal static Func<AzureBlobFileSystemOptions, BlobContainerClient> DefaultBlobContainerClientFactory => options => new BlobContainerClient(options.ConnectionString, options.ContainerName);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Recurses into the nested <see cref="Cache" /> options so its <see cref="IValidatableObject" /> implementation is honored by <c>ValidateDataAnnotations()</c>.
+    /// </remarks>
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (Cache is null)
+        {
+            yield break;
+        }
+
+        var nestedResults = new List<ValidationResult>();
+        Validator.TryValidateObject(Cache, new ValidationContext(Cache), nestedResults, validateAllProperties: true);
+
+        foreach (ValidationResult result in nestedResults)
+        {
+            yield return new ValidationResult(
+                result.ErrorMessage,
+                result.MemberNames.Select(member => $"{nameof(Cache)}.{member}"));
+        }
+    }
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemProvider.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemProvider.cs
@@ -7,13 +7,14 @@ using Umbraco.Cms.Core.IO;
 namespace Umbraco.StorageProviders.AzureBlob.IO;
 
 /// <inheritdoc />
-public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider
+public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider, IDisposable
 {
     private readonly ConcurrentDictionary<string, IAzureBlobFileSystem> _fileSystems = new();
     private readonly IOptionsMonitor<AzureBlobFileSystemOptions> _optionsMonitor;
     private readonly IHostingEnvironment _hostingEnvironment;
     private readonly IIOHelper _ioHelper;
     private readonly FileExtensionContentTypeProvider _fileExtensionContentTypeProvider;
+    private readonly IDisposable? _onChangeRegistration;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureBlobFileSystemProvider"/> class.
@@ -31,7 +32,13 @@ public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider
         _ioHelper = ioHelper ?? throw new ArgumentNullException(nameof(ioHelper));
         _fileExtensionContentTypeProvider = new FileExtensionContentTypeProvider();
 
-        _optionsMonitor.OnChange((options, name) => _fileSystems.TryRemove(name ?? Options.DefaultName, out _));
+        _onChangeRegistration = _optionsMonitor.OnChange((options, name) =>
+        {
+            if (_fileSystems.TryRemove(name ?? Options.DefaultName, out IAzureBlobFileSystem? removed) && removed is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        });
     }
 
     /// <inheritdoc />
@@ -46,5 +53,21 @@ public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider
 
             return new AzureBlobFileSystem(options, _hostingEnvironment, _ioHelper, _fileExtensionContentTypeProvider);
         });
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _onChangeRegistration?.Dispose();
+
+        foreach (IAzureBlobFileSystem fileSystem in _fileSystems.Values)
+        {
+            if (fileSystem is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+
+        _fileSystems.Clear();
     }
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/appsettings-schema.Umbraco.StorageProviders.AzureBlob.json
+++ b/src/Umbraco.StorageProviders.AzureBlob/appsettings-schema.Umbraco.StorageProviders.AzureBlob.json
@@ -79,6 +79,34 @@
           "type": "string",
           "description": "Gets or sets the virtual path.",
           "minLength": 1
+        },
+        "Cache": {
+          "$ref": "#/definitions/AzureBlobFileSystemCacheOptions"
+        }
+      }
+    },
+    "AzureBlobFileSystemCacheOptions": {
+      "type": "object",
+      "description": "In-memory cache settings applied to blob metadata lookups by the read-only file provider.",
+      "properties": {
+        "Enabled": {
+          "type": "boolean",
+          "description": "Gets or sets a value indicating whether blob metadata caching is enabled. Defaults to true."
+        },
+        "HitDuration": {
+          "type": "string",
+          "description": "Gets or sets how long a successful metadata lookup is cached. Defaults to 00:00:30.",
+          "format": "duration"
+        },
+        "MissDuration": {
+          "type": "string",
+          "description": "Gets or sets how long a not-found metadata result is cached. Defaults to 00:00:05.",
+          "format": "duration"
+        },
+        "SizeLimit": {
+          "type": "integer",
+          "description": "Gets or sets the maximum number of cached entries. Defaults to 10000.",
+          "minimum": 0
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add an in-memory cache for blob metadata (`IFileInfo`) returned by `AzureBlobFileProvider`, eliminating the per-request `BlobClient.GetProperties()` round-trip on the media serving hot path.
- Invalidate cache entries on writes through `AzureBlobFileSystem` (`AddFile`, `DeleteFile`, `DeleteDirectory`) so same-process changes are immediately visible.
- Cache lifecycle is owned by `AzureBlobFileSystem` (now `IDisposable`); `AzureBlobFileSystemProvider` disposes filesystems when options change at runtime or on app shutdown.

Mitigates #78 by short-circuiting the sync-over-async hot path for metadata lookups under load. Body downloads still go through `BlobClient.OpenRead()`; cache stampede protection is deferred to a future version targeting .NET 10 + `Microsoft.Extensions.Caching.Hybrid` (HybridCache).

### Configuration
New `Cache` block under `Umbraco:Storage:AzureBlob:{name}`:
- `Enabled` (default `true`)
- `HitDuration` (default `00:00:30`) — TTL for found entries
- `MissDuration` (default `00:00:05`) — shorter TTL for not-found entries so uploads become visible quickly
- `SizeLimit` (default `10000`) — bounded entry count

Validation runs through the existing `ValidateDataAnnotations()` registration via `IValidatableObject` on the parent options.

## Test plan
- [ ] `dotnet build` clean (no new warnings)
- [ ] Against Azurite: second `GetFileInfo` for the same path within `HitDuration` does not issue a `GetProperties` request
- [ ] `AddFile` followed by `GetFileInfo` returns fresh metadata immediately (cache invalidated)
- [ ] `DeleteFile` followed by `GetFileInfo` returns `NotFoundFileInfo` immediately
- [ ] Misconfigured `Cache:HitDuration = 00:00:00` fails startup with a clear `OptionsValidationException` pointing at `Cache.HitDuration`