### PR TITLE
Add configurable retry and timeout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,15 +156,71 @@ The available options are:
 - `MissDuration` - how long a not-found result is cached; kept shorter than `HitDuration` so newly-uploaded blobs become visible quickly (default 5 seconds).
 - `SizeLimit` - the maximum number of cached entries, each counting as a single unit (default 10,000).
 
+### Retry and timeout options
+The Azure SDK's default retry policy is tuned for background jobs, not request-serving: it allows 3 retries with a 100-second network timeout each, so a single failing blob call can tie up a thread for several minutes. To bound the worst-case time a blob operation spends waiting on blob storage, the provider applies more conservative retry and timeout defaults to the default `BlobContainerClient`.
+
+These can be configured in code:
+```csharp
+using Azure.Core;
+
+.AddAzureBlobMediaFileSystem(options => {
+    options.Retry.MaxRetries = 2;
+    options.Retry.NetworkTimeout = TimeSpan.FromSeconds(30);
+    options.Retry.Mode = RetryMode.Exponential;
+    options.Retry.Delay = TimeSpan.FromMilliseconds(800);
+    options.Retry.MaxDelay = TimeSpan.FromSeconds(5);
+})
+```
+
+In `appsettings.json` (durations use the `hh:mm:ss` format):
+```json
+{
+  "Umbraco": {
+    "Storage": {
+      "AzureBlob": {
+        "Media": {
+          "Retry": {
+            "MaxRetries": 2,
+            "NetworkTimeout": "00:00:30",
+            "Mode": "Exponential",
+            "Delay": "00:00:00.800",
+            "MaxDelay": "00:00:05"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Or by environment variables:
+```sh
+UMBRACO__STORAGE__AZUREBLOB__MEDIA__RETRY__MAXRETRIES=2
+UMBRACO__STORAGE__AZUREBLOB__MEDIA__RETRY__NETWORKTIMEOUT=00:00:30
+UMBRACO__STORAGE__AZUREBLOB__MEDIA__RETRY__MODE=Exponential
+UMBRACO__STORAGE__AZUREBLOB__MEDIA__RETRY__DELAY=00:00:00.800
+UMBRACO__STORAGE__AZUREBLOB__MEDIA__RETRY__MAXDELAY=00:00:05
+```
+
+The available options are:
+- `MaxRetries` - the maximum number of retry attempts before giving up (default 2).
+- `NetworkTimeout` - the timeout applied to an individual network operation (default 30 seconds). This also bounds uploads, so keep it high enough to transfer your largest media files in a single operation.
+- `Mode` - the approach used to calculate retry delays, `Exponential` or `Fixed` (default `Exponential`).
+- `Delay` - the delay between retries for `Fixed` mode, or the base delay for backoff calculations in `Exponential` mode (default 800 milliseconds).
+- `MaxDelay` - the maximum permissible delay between retries when using a backoff approach (default 5 seconds).
+
+> **Note**
+> These settings are only honored by the default `BlobContainerClient` factory. If you supply a custom `BlobClientOptions` (see [Custom blob container options](#custom-blob-container-options) below), call `options.ConfigureRetry(blobClientOptions)` to apply the retry policy.
+
 ### Custom blob container options
 To override the default blob container options, you can use the following extension methods on `AzureBlobFileSystemOptions`:
 ```csharp
 // Add using default options (overly verbose, but shows how to revert back to the default)
 .AddAzureBlobMediaFileSystem(options => options.CreateBlobContainerClientUsingDefault())
-// Add using options
-.AddAzureBlobMediaFileSystem(options => options.CreateBlobContainerClientUsingOptions(_blobClientOptions))
+// Add using options (call ConfigureRetry to keep applying the configured retry policy)
+.AddAzureBlobMediaFileSystem(options => options.CreateBlobContainerClientUsingOptions(options.ConfigureRetry(_blobClientOptions)))
 // If the connection string is parsed to a URI, use the delegate to create a BlobContainerClient
-.AddAzureBlobMediaFileSystem(options => options.TryCreateBlobContainerClientUsingUri(uri => new BlobContainerClient(uri, _blobClientOptions)))
+.AddAzureBlobMediaFileSystem(options => options.TryCreateBlobContainerClientUsingUri(uri => new BlobContainerClient(uri, options.ConfigureRetry(_blobClientOptions))))
 ```
 
 This can also be used together with the `Azure.Identity` package to authenticate with Azure AD (using managed identities):
@@ -181,7 +237,7 @@ internal sealed class AzureBlobFileSystemComposer : IComposer
         {
             options.ConnectionString = "https://[storage-account].blob.core.windows.net";
             options.ContainerName = "media";
-            options.TryCreateBlobContainerClientUsingUri(uri => new BlobContainerClient(uri, new DefaultAzureCredential()));
+            options.TryCreateBlobContainerClientUsingUri(uri => new BlobContainerClient(uri, new DefaultAzureCredential(), options.ConfigureRetry(new BlobClientOptions())));
         });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Caching is enabled by default. It can be configured in code:
 })
 ```
 
-In `appsettings.json` (durations use the `hh:mm:ss` format):
+In `appsettings.json` (durations use the `hh:mm:ss[.fff]` format):
 ```json
 {
   "Umbraco": {
@@ -172,7 +172,7 @@ using Azure.Core;
 })
 ```
 
-In `appsettings.json` (durations use the `hh:mm:ss` format):
+In `appsettings.json` (durations use the `hh:mm:ss[.fff]` format):
 ```json
 {
   "Umbraco": {

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
 using Azure.Storage.Blobs;
 
 namespace Umbraco.StorageProviders.AzureBlob.IO;
@@ -79,39 +80,10 @@ public sealed class AzureBlobFileSystemOptions : IValidatableObject
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="blobClientOptions" /> is <c>null</c>.</exception>
     /// <remarks>
-    /// Use this when supplying a custom <see cref="BlobClientOptions" /> (e.g. via
-    /// <see cref="AzureBlobFileSystemOptionsExtensions.CreateBlobContainerClientUsingOptions" />) to ensure the same retry policy is applied.
+    /// Use this when supplying a custom <see cref="BlobClientOptions" /> (e.g. via <see cref="AzureBlobFileSystemOptionsExtensions.CreateBlobContainerClientUsingOptions" />) to ensure the same retry policy is applied.
     /// </remarks>
     public BlobClientOptions ConfigureRetry(BlobClientOptions blobClientOptions)
-        => ConfigureRetry(blobClientOptions, Retry);
-
-    /// <summary>
-    /// Applies the configured retry and timeout settings to the supplied <see cref="BlobClientOptions" />.
-    /// </summary>
-    /// <param name="blobClientOptions">The Blob client options to configure.</param>
-    /// <param name="retry">The retry and timeout settings to apply.</param>
-    /// <returns>
-    /// The same <paramref name="blobClientOptions" /> instance, to allow fluent chaining.
-    /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="blobClientOptions" /> is <c>null</c>.</exception>
-    /// <exception cref="ArgumentNullException"><paramref name="retry" /> is <c>null</c>.</exception>
-    /// <remarks>
-    /// Use this when supplying a custom <see cref="BlobClientOptions" /> (e.g. via
-    /// <see cref="AzureBlobFileSystemOptionsExtensions.CreateBlobContainerClientUsingOptions" />) to ensure the same retry policy is applied.
-    /// </remarks>
-    public static BlobClientOptions ConfigureRetry(BlobClientOptions blobClientOptions, AzureBlobFileSystemRetryOptions retry)
-    {
-        ArgumentNullException.ThrowIfNull(blobClientOptions);
-        ArgumentNullException.ThrowIfNull(retry);
-
-        blobClientOptions.Retry.MaxRetries = retry.MaxRetries;
-        blobClientOptions.Retry.NetworkTimeout = retry.NetworkTimeout;
-        blobClientOptions.Retry.Mode = retry.Mode;
-        blobClientOptions.Retry.Delay = retry.Delay;
-        blobClientOptions.Retry.MaxDelay = retry.MaxDelay;
-
-        return blobClientOptions;
-    }
+        => Retry.Configure(blobClientOptions);
 
     /// <inheritdoc />
     /// <remarks>
@@ -120,11 +92,22 @@ public sealed class AzureBlobFileSystemOptions : IValidatableObject
     /// </remarks>
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
-        var results = new List<ValidationResult>();
+        return [..ValidateObject(Cache), ..ValidateObject(Retry)];
 
-        Validator.TryValidateObject(Cache, new ValidationContext(Cache), results, validateAllProperties: true);
-        Validator.TryValidateObject(Retry, new ValidationContext(Retry), results, validateAllProperties: true);
+        static IEnumerable<ValidationResult> ValidateObject(object? instance, [CallerArgumentExpression(nameof(instance))] string? prefix = null)
+        {
+            if (instance is null)
+            {
+                yield break;
+            }
 
-        return results;
+            var validationResults = new List<ValidationResult>();
+            Validator.TryValidateObject(instance, new ValidationContext(instance), validationResults, validateAllProperties: true);
+
+            foreach (ValidationResult validationResult in validationResults)
+            {
+                yield return new ValidationResult(validationResult.ErrorMessage, validationResult.MemberNames.Select(member => $"{prefix}.{member}"));
+            }
+        }
     }
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemOptions.cs
@@ -45,6 +45,16 @@ public sealed class AzureBlobFileSystemOptions : IValidatableObject
     public AzureBlobFileSystemCacheOptions Cache { get; set; } = new();
 
     /// <summary>
+    /// Gets or sets the retry and timeout settings applied to the default Blob client.
+    /// </summary>
+    /// <remarks>
+    /// Only honored by the default factory. If a custom <see cref="BlobClientOptions" /> is supplied via
+    /// <see cref="AzureBlobFileSystemOptionsExtensions.CreateBlobContainerClientUsingOptions" /> or another override,
+    /// these values are ignored and the supplied options are used as-is.
+    /// </remarks>
+    public AzureBlobFileSystemRetryOptions Retry { get; set; } = new();
+
+    /// <summary>
     /// Gets or sets the Azure Blob Container client factory.
     /// </summary>
     /// <value>
@@ -58,27 +68,63 @@ public sealed class AzureBlobFileSystemOptions : IValidatableObject
     /// <value>
     /// The default Azure Blob Container client factory.
     /// </value>
-    internal static Func<AzureBlobFileSystemOptions, BlobContainerClient> DefaultBlobContainerClientFactory => options => new BlobContainerClient(options.ConnectionString, options.ContainerName);
+    internal static Func<AzureBlobFileSystemOptions, BlobContainerClient> DefaultBlobContainerClientFactory => options => new BlobContainerClient(options.ConnectionString, options.ContainerName, options.ConfigureRetry(new BlobClientOptions()));
+
+    /// <summary>
+    /// Applies the <see cref="Retry" /> settings from this options instance to the supplied <see cref="BlobClientOptions" />.
+    /// </summary>
+    /// <param name="blobClientOptions">The Blob client options to configure.</param>
+    /// <returns>
+    /// The same <paramref name="blobClientOptions" /> instance, to allow fluent chaining.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="blobClientOptions" /> is <c>null</c>.</exception>
+    /// <remarks>
+    /// Use this when supplying a custom <see cref="BlobClientOptions" /> (e.g. via
+    /// <see cref="AzureBlobFileSystemOptionsExtensions.CreateBlobContainerClientUsingOptions" />) to ensure the same retry policy is applied.
+    /// </remarks>
+    public BlobClientOptions ConfigureRetry(BlobClientOptions blobClientOptions)
+        => ConfigureRetry(blobClientOptions, Retry);
+
+    /// <summary>
+    /// Applies the configured retry and timeout settings to the supplied <see cref="BlobClientOptions" />.
+    /// </summary>
+    /// <param name="blobClientOptions">The Blob client options to configure.</param>
+    /// <param name="retry">The retry and timeout settings to apply.</param>
+    /// <returns>
+    /// The same <paramref name="blobClientOptions" /> instance, to allow fluent chaining.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="blobClientOptions" /> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="retry" /> is <c>null</c>.</exception>
+    /// <remarks>
+    /// Use this when supplying a custom <see cref="BlobClientOptions" /> (e.g. via
+    /// <see cref="AzureBlobFileSystemOptionsExtensions.CreateBlobContainerClientUsingOptions" />) to ensure the same retry policy is applied.
+    /// </remarks>
+    public static BlobClientOptions ConfigureRetry(BlobClientOptions blobClientOptions, AzureBlobFileSystemRetryOptions retry)
+    {
+        ArgumentNullException.ThrowIfNull(blobClientOptions);
+        ArgumentNullException.ThrowIfNull(retry);
+
+        blobClientOptions.Retry.MaxRetries = retry.MaxRetries;
+        blobClientOptions.Retry.NetworkTimeout = retry.NetworkTimeout;
+        blobClientOptions.Retry.Mode = retry.Mode;
+        blobClientOptions.Retry.Delay = retry.Delay;
+        blobClientOptions.Retry.MaxDelay = retry.MaxDelay;
+
+        return blobClientOptions;
+    }
 
     /// <inheritdoc />
     /// <remarks>
-    /// Recurses into the nested <see cref="Cache" /> options so its <see cref="IValidatableObject" /> implementation is honored by <c>ValidateDataAnnotations()</c>.
+    /// Recurses into the nested <see cref="Cache" /> and <see cref="Retry" /> options so their validation attributes and
+    /// <see cref="IValidatableObject" /> implementations are honored by <c>ValidateDataAnnotations()</c>.
     /// </remarks>
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
-        if (Cache is null)
-        {
-            yield break;
-        }
+        var results = new List<ValidationResult>();
 
-        var nestedResults = new List<ValidationResult>();
-        Validator.TryValidateObject(Cache, new ValidationContext(Cache), nestedResults, validateAllProperties: true);
+        Validator.TryValidateObject(Cache, new ValidationContext(Cache), results, validateAllProperties: true);
+        Validator.TryValidateObject(Retry, new ValidationContext(Retry), results, validateAllProperties: true);
 
-        foreach (ValidationResult result in nestedResults)
-        {
-            yield return new ValidationResult(
-                result.ErrorMessage,
-                result.MemberNames.Select(member => $"{nameof(Cache)}.{member}"));
-        }
+        return results;
     }
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemRetryOptions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemRetryOptions.cs
@@ -71,6 +71,30 @@ public sealed class AzureBlobFileSystemRetryOptions : IValidatableObject
     [DefaultValue(typeof(TimeSpan), DefaultMaxDelay)]
     public TimeSpan MaxDelay { get; set; } = TimeSpan.Parse(DefaultMaxDelay, CultureInfo.InvariantCulture);
 
+    /// <summary>
+    /// Configures the supplied <see cref="BlobClientOptions" /> with these retry and timeout settings.
+    /// </summary>
+    /// <param name="blobClientOptions">The Blob client options to configure.</param>
+    /// <returns>
+    /// The same <paramref name="blobClientOptions" /> instance, to allow fluent chaining.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="blobClientOptions" /> is <c>null</c>.</exception>
+    /// <remarks>
+    /// Use this when supplying a custom <see cref="BlobClientOptions" /> (e.g. via <see cref="AzureBlobFileSystemOptionsExtensions.CreateBlobContainerClientUsingOptions" />) to ensure the same retry policy is applied.
+    /// </remarks>
+    public BlobClientOptions Configure(BlobClientOptions blobClientOptions)
+    {
+        ArgumentNullException.ThrowIfNull(blobClientOptions);
+
+        blobClientOptions.Retry.MaxRetries = MaxRetries;
+        blobClientOptions.Retry.NetworkTimeout = NetworkTimeout;
+        blobClientOptions.Retry.Mode = Mode;
+        blobClientOptions.Retry.Delay = Delay;
+        blobClientOptions.Retry.MaxDelay = MaxDelay;
+
+        return blobClientOptions;
+    }
+
     /// <inheritdoc />
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemRetryOptions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemRetryOptions.cs
@@ -1,0 +1,92 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using Azure.Core;
+using Azure.Storage.Blobs;
+
+namespace Umbraco.StorageProviders.AzureBlob.IO;
+
+/// <summary>
+/// Retry and timeout settings applied to the default <see cref="BlobContainerClient" /> created from <see cref="AzureBlobFileSystemOptions" />.
+/// </summary>
+/// <remarks>
+/// These defaults are intentionally more conservative than the Azure SDK defaults to bound the worst-case time a
+/// blob operation can spend waiting on blob storage (the default SDK policy permits 3 retries with a 100-second
+/// network timeout each, which can tie up a thread for several minutes per call). As these settings also apply to
+/// writes, <see cref="NetworkTimeout" /> must remain high enough to upload the largest media files in a single operation.
+/// </remarks>
+public sealed class AzureBlobFileSystemRetryOptions : IValidatableObject
+{
+    private const int DefaultMaxRetries = 2;
+    private const string DefaultNetworkTimeout = "00:00:30";
+    private const RetryMode DefaultMode = RetryMode.Exponential;
+    private const string DefaultDelay = "00:00:00.800";
+    private const string DefaultMaxDelay = "00:00:05";
+
+    /// <summary>
+    /// Gets or sets the maximum number of retry attempts before giving up.
+    /// </summary>
+    /// <value>
+    /// The maximum retries.
+    /// </value>
+    [DefaultValue(DefaultMaxRetries)]
+    [Range(0, int.MaxValue, ErrorMessage = "{0} must be a non-negative integer.")]
+    public int MaxRetries { get; set; } = DefaultMaxRetries;
+
+    /// <summary>
+    /// Gets or sets the timeout applied to an individual network operation.
+    /// </summary>
+    /// <value>
+    /// The network timeout.
+    /// </value>
+    [DefaultValue(typeof(TimeSpan), DefaultNetworkTimeout)]
+    public TimeSpan NetworkTimeout { get; set; } = TimeSpan.Parse(DefaultNetworkTimeout, CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Gets or sets the approach to use for calculating retry delays.
+    /// </summary>
+    /// <value>
+    /// The mode.
+    /// </value>
+    [DefaultValue(DefaultMode)]
+    [EnumDataType(typeof(RetryMode), ErrorMessage = "{0} must be a valid retry mode.")]
+    public RetryMode Mode { get; set; } = DefaultMode;
+
+    /// <summary>
+    /// Gets or sets the delay between retry attempts for a fixed approach or the delay on which to base
+    /// calculations for a backoff-based approach.
+    /// </summary>
+    /// <value>
+    /// The delay.
+    /// </value>
+    [DefaultValue(typeof(TimeSpan), DefaultDelay)]
+    public TimeSpan Delay { get; set; } = TimeSpan.Parse(DefaultDelay, CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Gets or sets the maximum permissible delay between retry attempts when using a backoff approach.
+    /// </summary>
+    /// <value>
+    /// The maximum delay.
+    /// </value>
+    [DefaultValue(typeof(TimeSpan), DefaultMaxDelay)]
+    public TimeSpan MaxDelay { get; set; } = TimeSpan.Parse(DefaultMaxDelay, CultureInfo.InvariantCulture);
+
+    /// <inheritdoc />
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (NetworkTimeout <= TimeSpan.Zero)
+        {
+            yield return new ValidationResult($"{nameof(NetworkTimeout)} must be a positive duration; got {NetworkTimeout}.", [nameof(NetworkTimeout)]);
+        }
+
+        if (Delay < TimeSpan.Zero)
+        {
+            yield return new ValidationResult($"{nameof(Delay)} must be a non-negative duration; got {Delay}.", [nameof(Delay)]);
+        }
+
+        if (MaxDelay < TimeSpan.Zero)
+        {
+            yield return new ValidationResult($"{nameof(MaxDelay)} must be a non-negative duration; got {MaxDelay}.", [nameof(MaxDelay)]);
+        }
+    }
+}

--- a/src/Umbraco.StorageProviders.AzureBlob/appsettings-schema.Umbraco.StorageProviders.AzureBlob.json
+++ b/src/Umbraco.StorageProviders.AzureBlob/appsettings-schema.Umbraco.StorageProviders.AzureBlob.json
@@ -82,6 +82,9 @@
         },
         "Cache": {
           "$ref": "#/definitions/AzureBlobFileSystemCacheOptions"
+        },
+        "Retry": {
+          "$ref": "#/definitions/AzureBlobFileSystemRetryOptions"
         }
       }
     },
@@ -107,6 +110,40 @@
           "type": "integer",
           "description": "Gets or sets the maximum number of cached entries. Defaults to 10000.",
           "minimum": 0
+        }
+      }
+    },
+    "AzureBlobFileSystemRetryOptions": {
+      "type": "object",
+      "description": "Retry and timeout settings applied to the default Blob client. Only honored when a custom BlobClientOptions is not supplied via a factory override.",
+      "properties": {
+        "MaxRetries": {
+          "type": "integer",
+          "description": "Gets or sets the maximum number of retry attempts before giving up. Defaults to 2.",
+          "minimum": 0
+        },
+        "NetworkTimeout": {
+          "type": "string",
+          "description": "Gets or sets the timeout applied to an individual network operation. Defaults to 00:00:30.",
+          "format": "duration"
+        },
+        "Mode": {
+          "type": "string",
+          "description": "Gets or sets the approach to use for calculating retry delays. Defaults to Exponential.",
+          "enum": [
+            "Exponential",
+            "Fixed"
+          ]
+        },
+        "Delay": {
+          "type": "string",
+          "description": "Gets or sets the delay between retry attempts (Fixed mode) or the base delay used for backoff calculations (Exponential mode). Defaults to 00:00:00.800.",
+          "format": "duration"
+        },
+        "MaxDelay": {
+          "type": "string",
+          "description": "Gets or sets the maximum permissible delay between retry attempts when using a backoff approach. Defaults to 00:00:05.",
+          "format": "duration"
         }
       }
     }


### PR DESCRIPTION
## Summary

Adds configurable retry and timeout options for the Azure Blob `BlobContainerClient`, with conservative defaults that bound the worst-case time a blob operation can spend waiting on storage.

The default Azure SDK retry policy is tuned for background jobs (3 retries × 100-second network timeout), so a single failing call can tie up a thread for several minutes — undesirable on the request-serving / media hot path. This introduces an `AzureBlobFileSystemRetryOptions` block on `AzureBlobFileSystemOptions.Retry` with more conservative defaults.

## Changes

- **`AzureBlobFileSystemRetryOptions`** — new options class exposing `MaxRetries` (2), `NetworkTimeout` (30s), `Mode` (Exponential), `Delay` (800ms) and `MaxDelay` (5s), mapping directly onto `Azure.Core.RetryOptions`.
  - Defaults stored in `const` fields, reused by both `[DefaultValue]` attributes and property initializers so they can't drift.
  - Validation: `[Range]`/`[EnumDataType]` attributes for `MaxRetries`/`Mode`, and `IValidatableObject` for the duration checks (mirroring `AzureBlobFileSystemCacheOptions`).
- **`AzureBlobFileSystemOptions`** — adds the `Retry` property; the default `BlobContainerClient` factory now applies these via the new `ConfigureRetry(...)` helper; `Validate()` recurses into both `Cache` and `Retry`.
- **`ConfigureRetry`** — public helper so callers supplying a custom `BlobClientOptions` (custom factory / managed-identity URI auth) can apply the same retry policy. A custom factory otherwise bypasses these settings.
- **Schema & README** — appsettings schema entries and a documented "Retry and timeout options" section, including `ConfigureRetry` usage in the custom-factory examples.

## Notes

- `NetworkTimeout` defaults to **30s** rather than something more aggressive because these options also govern **writes** — a single `Put Blob` for a larger media file must complete within one network operation.
- These settings are only applied automatically by the default factory; custom factories must call `ConfigureRetry` (documented).

Built on top of the cache-options work merged in #84.