### PR TITLE
Add NuGet release and SBOM generation stages to build pipeline

### DIFF
--- a/Umbraco.StorageProviders.sln
+++ b/Umbraco.StorageProviders.sln
@@ -14,6 +14,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		azure-pipelines.yml = azure-pipelines.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
+		generate-sbom.yml = generate-sbom.yml
 		global.json = global.json
 		icon.png = icon.png
 		LICENSE = LICENSE

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,36 @@ parameters:
   - name: cache_nuget
     displayName: Cache NuGet packages
     type: boolean
-    default: false
+    default: false # Disabled by default due to MyGet allowing version overwrite, which can cause issues with cached packages from previous runs
+  - name: release_myget
+    displayName: Release to MyGet
+    type: string
+    default: auto
+    values:
+      - auto # Only release to MyGet on public releases, otherwise skip
+      - prerelease # Release to MyGet pre-release feed, regardless of release type
+      - nightly # Release to MyGet nightly feed, regardless of release type
+      - skip # Skip releasing to MyGet, regardless of release type
+  - name: release
+    displayName: Release
+    type: string
+    default: auto
+    values:
+      - auto # Only release to NuGet on public releases, otherwise skip
+      - public # Release to NuGet, regardless of release type
+      - skip # Skip releasing to NuGet, regardless of release type
+  - name: sbom
+    displayName: SBOM
+    type: string
+    default: auto
+    values:
+      - auto # Only generate SBOM for develop and support/* branches, otherwise skip
+      - force # Generate SBOM, regardless of branch
+      - skip # Skip generating SBOM, regardless of branch
 
 variables:
   solution: Umbraco.StorageProviders.sln
+  vmImage: 'ubuntu-latest'
   buildConfiguration: Release
   DOTNET_NOLOGO: true
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
@@ -27,7 +53,7 @@ stages:
     jobs:
       - job: Build
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: $(vmImage)
         steps:
           # Checkout source (avoid shallow clone to calculate version height)
           - checkout: self
@@ -56,14 +82,109 @@ stages:
           # Build
           - script: dotnet build $(solution) --configuration $(buildConfiguration) --no-restore -p:ContinuousIntegrationBuild=true
             displayName: Run dotnet build
+            name: build
 
           # Pack
           - script: dotnet pack $(solution) --configuration $(buildConfiguration) --no-build --output $(Build.ArtifactStagingDirectory)/nupkg
             displayName: Run dotnet pack
 
           # Publish
-          - task: PublishPipelineArtifact@1
+          - publish: $(Build.ArtifactStagingDirectory)/nupkg
+            artifact: nupkg
             displayName: Publish NuGet packages
+
+  - stage: ReleaseMyGet
+    displayName: Release to MyGet
+    dependsOn:
+      - Build
+    condition: |
+      and(
+        succeeded('Build'),
+        ne('${{ parameters.release_myget }}', 'skip'),
+        or(
+          ne('${{ parameters.release_myget }}', 'auto'),
+          eq(dependencies.Build.outputs['Build.build.NBGV_PublicRelease'], true)
+        )
+      )
+    jobs:
+      - job: NuGet
+        pool:
+          vmImage: 'windows-latest' # NuGetCommand@2 requires Mono and is no longer supported on Ubuntu 24.04+
+        steps:
+          - checkout: none
+
+          - download: current
+            artifact: nupkg
+            displayName: Download nupkg artifact
+
+          - task: NuGetCommand@2
+            displayName: NuGet push
             inputs:
-              targetPath: $(Build.ArtifactStagingDirectory)/nupkg
-              artifactName: nupkg
+              command: push
+              packagesToPush: '$(Pipeline.Workspace)/nupkg/*.nupkg'
+              nuGetFeedType: external
+              ${{ if eq(parameters.release_myget, 'nightly') }}:
+                publishFeedCredentials: 'MyGet - Nightly'
+              ${{ else }}:
+                publishFeedCredentials: 'MyGet - Pre-releases'
+
+  - stage: Release
+    dependsOn:
+      - Build
+      - ReleaseMyGet
+    condition: |
+      and(
+        succeeded('Build'),
+        ne('${{ parameters.release }}', 'skip'),
+        or(
+          ne('${{ parameters.release }}', 'auto'),
+          eq(dependencies.Build.outputs['Build.build.NBGV_PublicRelease'], true)
+        )
+      )
+    jobs:
+      - job: NuGet
+        pool:
+          vmImage: 'windows-latest' # NuGetCommand@2 requires Mono and is no longer supported on Ubuntu 24.04+
+        steps:
+          - checkout: none
+
+          - download: current
+            artifact: nupkg
+            displayName: Download nupkg artifact
+
+          - task: NuGetCommand@2
+            displayName: NuGet push
+            inputs:
+              command: push
+              packagesToPush: '$(Pipeline.Workspace)/nupkg/*.nupkg'
+              nuGetFeedType: external
+              publishFeedCredentials: 'NuGet'
+
+  # Generate SBOM on development branches
+  - stage: SBOM
+    dependsOn: Build
+    condition: |
+      and(
+        succeeded(),
+        ne('${{ parameters.sbom }}', 'skip'),
+        or(
+          ne('${{ parameters.sbom }}', 'auto'),
+          eq(variables['Build.SourceBranch'], 'refs/heads/develop'),
+          startsWith(variables['Build.SourceBranch'], 'refs/heads/support/')
+        )
+      )
+    variables:
+      majorVersion: $[ stageDependencies.Build.Build.outputs['build.NBGV_VersionMajor'] ]
+    jobs:
+      - job: GenerateSBOM
+        displayName: Generate SBOM
+        pool:
+          vmImage: $(vmImage)
+        steps:
+          - template: generate-sbom.yml
+            parameters:
+              productGroup: 'Umbraco'
+              productName: 'Umbraco.StorageProviders'
+              baseUrl: $(DT_BASE_URL)
+              apiKey: $(DT_API_KEY)
+              majorVersion: $(majorVersion)

--- a/generate-sbom.yml
+++ b/generate-sbom.yml
@@ -1,0 +1,51 @@
+---
+# SBOM Generation Template
+#
+# Generates Software Bill of Materials (SBOM) using CycloneDX cdxgen and uploads to Dependency Track for security vulnerability tracking.
+
+parameters:
+  - name: productGroup
+    type: string
+  - name: productName
+    type: string
+  - name: baseUrl
+    type: string
+  - name: apiKey
+    type: string
+  - name: majorVersion
+    type: string
+
+steps:
+  - script: |
+      # Verify Dependency Track configuration
+      MISSING=""
+      if [ -z "${{ parameters.baseUrl }}" ]; then
+        echo "##vso[task.logissue type=error]Dependency Track base URL is not configured"
+        MISSING="true"
+      fi
+      if [ -z "${{ parameters.apiKey }}" ]; then
+        echo "##vso[task.logissue type=error]Dependency Track API key is not configured"
+        MISSING="true"
+      fi
+      if [ -n "$MISSING" ]; then
+        echo "##vso[task.complete result=Skipped;]Skipping SBOM generation - missing required configuration variables"
+        exit 0
+      fi
+      # Generate and upload SBOM
+      mkdir -p $(Build.ArtifactStagingDirectory)/sbom
+      npx @cyclonedx/cdxgen --recurse \
+        --output $(Build.ArtifactStagingDirectory)/sbom/sbom.json \
+        --spec-version 1.6 \
+        --json-pretty \
+        --project-group "${{ parameters.productGroup }}" \
+        --project-name "${{ parameters.productName }}" \
+        --project-version "v${{ parameters.majorVersion }}" \
+        --server-url "${{ parameters.baseUrl }}" \
+        --api-key "${{ parameters.apiKey }}"
+    displayName: 'Generate and upload SBOM'
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish SBOM artifact'
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)/sbom
+      artifactName: sbom

--- a/version.json
+++ b/version.json
@@ -13,6 +13,7 @@
     "^refs/tags/release-"
   ],
   "cloudBuild": {
+    "setAllVariables": true,
     "buildNumber": {
       "enabled": true
     }


### PR DESCRIPTION
## Summary

Extends `azure-pipelines.yml` with **release stages** (MyGet + NuGet) and an **SBOM generation stage** on top of the existing build flow.

## Stages

- **Build** — restore/build/pack and publish the `nupkg` artifact. The build step is named `build` so downstream stages can read its NBGV outputs.
- **ReleaseMyGet** — push `nupkg` to the MyGet pre-release (or nightly) feed. Auto-runs only on public releases.
- **Release** — push `nupkg` to NuGet. Auto-runs only on public releases.
- **SBOM** — generate a CycloneDX SBOM (`generate-sbom.yml`) and upload to Dependency Track; auto-runs on `develop` and `support/*`.

Releasing is controlled by `auto`/`skip`/`force`-style string parameters (`release_myget`, `release`, `sbom`), plus `cache_nuget` (default `false`, since MyGet allows version overwrite which can break cached packages).

## Required companion change

- **`version.json`** — added `cloudBuild.setAllVariables: true`. This makes NBGV emit the full set of `NBGV_*` cloud variables; the release stage conditions (`NBGV_PublicRelease`) and the SBOM `majorVersion` (`NBGV_VersionMajor`) depend on it. Without it, auto-release never fires and the SBOM version is empty. `publicReleaseRefSpec` is unchanged (public release on `release-*` tags).

## Notes / setup

- Restores from public feeds, so no `NuGetAuthenticate` step is required.
- Service connections `MyGet - Pre-releases`, `MyGet - Nightly`, and `NuGet` must exist and be authorized for this pipeline.
- On a **public release** (a `release-*` tag) both ReleaseMyGet and Release run by default, i.e. the package is pushed to MyGet pre-releases *and* NuGet — adjust `release_myget` if that's not desired.
- The SBOM stage uses the existing `DT_BASE_URL` / `DT_API_KEY` pipeline variables; the template no-ops if they're unset.

Also adds `generate-sbom.yml` to the solution items.