### PR TITLE
Use HybridCache for blob metadata caching

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.0.0" />
     <PackageVersion Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.2.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="Umbraco.Cms.Imaging.ImageSharp" Version="$(UmbracoCmsPackageVersion)" />
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="$(UmbracoCmsPackageVersion)" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ UMBRACO__STORAGE__AZUREBLOB__MEDIA__CONTAINERNAME=sample-container
 > You still have to add the provider in the `Program.cs` file when not configuring the options in code.
 
 ### Blob metadata caching
-The read-only file provider serving media performs a synchronous metadata lookup (`GetProperties()`) against Azure Blob Storage on every request. Under load the default Azure SDK retry policy can hold a thread for many seconds per call, so the provider caches blob metadata (size and last modified) in-memory per blob path to avoid the round-trip on the steady-state hot path, reducing both latency and thread-pool pressure.
+The read-only file provider serving media performs a synchronous metadata lookup (`GetProperties()`) against Azure Blob Storage on every request. Under load the default Azure SDK retry policy can hold a thread for many seconds per call, so the provider caches blob metadata (size and last modified) per blob path to avoid the round-trip on the steady-state hot path, reducing both latency and thread-pool pressure. Caching is backed by the shared `HybridCache` registered by Umbraco, which provides built-in stampede protection so concurrent requests for the same cold key share a single fetch.
 
 Writes through the file system (`AddFile`/`DeleteFile`/`DeleteDirectory`) invalidate the affected cache entries immediately, so only writes performed outside this instance (another process, another instance, or directly via the Azure SDK) can leave metadata stale for up to the configured hit duration.
 
@@ -111,7 +111,6 @@ Caching is enabled by default. It can be configured in code:
     options.Cache.Enabled = true;
     options.Cache.HitDuration = TimeSpan.FromSeconds(30);
     options.Cache.MissDuration = TimeSpan.FromSeconds(5);
-    options.Cache.SizeLimit = 10_000;
 })
 ```
 
@@ -125,8 +124,7 @@ In `appsettings.json` (durations use the `hh:mm:ss[.fff]` format):
           "Cache": {
             "Enabled": true,
             "HitDuration": "00:00:30",
-            "MissDuration": "00:00:05",
-            "SizeLimit": 10000
+            "MissDuration": "00:00:05"
           }
         }
       }
@@ -140,14 +138,12 @@ Or by environment variables:
 UMBRACO__STORAGE__AZUREBLOB__MEDIA__CACHE__ENABLED=true
 UMBRACO__STORAGE__AZUREBLOB__MEDIA__CACHE__HITDURATION=00:00:30
 UMBRACO__STORAGE__AZUREBLOB__MEDIA__CACHE__MISSDURATION=00:00:05
-UMBRACO__STORAGE__AZUREBLOB__MEDIA__CACHE__SIZELIMIT=10000
 ```
 
 The available options are:
 - `Enabled` - whether blob metadata caching is enabled (default `true`).
 - `HitDuration` - how long a successful metadata lookup is cached (default 30 seconds).
 - `MissDuration` - how long a not-found result is cached; kept shorter than `HitDuration` so newly-uploaded blobs become visible quickly (default 5 seconds).
-- `SizeLimit` - the maximum number of cached entries, each counting as a single unit (default 10,000).
 
 ### Retry and timeout options
 The Azure SDK's default retry policy is tuned for background jobs, not request-serving: it allows 3 retries with a 100-second network timeout each, so a single failing blob call can tie up a thread for several minutes. To bound the worst-case time a blob operation spends waiting on blob storage, the provider applies more conservative retry and timeout defaults to the default `BlobContainerClient`.

--- a/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileProvider.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/AzureBlobFileProvider.cs
@@ -1,9 +1,11 @@
-using System.Diagnostics.CodeAnalysis;
+using System.ComponentModel;
+using System.IO.Hashing;
 using System.Net;
+using System.Runtime.InteropServices;
 using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
-using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 using Umbraco.Cms.Core;
@@ -20,8 +22,7 @@ public sealed class AzureBlobFileProvider : IFileProvider
 {
     private readonly BlobContainerClient _containerClient;
     private readonly string? _containerRootPath;
-    private readonly IMemoryCache? _cache;
-    private readonly AzureBlobFileSystemCacheOptions? _cacheOptions;
+    private readonly (HybridCache Cache, HybridCacheEntryOptions HitEntryOptions, HybridCacheEntryOptions MissEntryOptions)? _cache;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AzureBlobFileProvider" /> class.
@@ -36,20 +37,38 @@ public sealed class AzureBlobFileProvider : IFileProvider
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AzureBlobFileProvider" /> class with blob metadata caching backed by a caller-supplied <see cref="IMemoryCache" />.
+    /// Initializes a new instance of the <see cref="AzureBlobFileProvider" /> class with blob metadata caching backed by a caller-supplied <see cref="HybridCache" />.
     /// </summary>
     /// <param name="containerClient">The container client.</param>
     /// <param name="containerRootPath">The container root path.</param>
-    /// <param name="cache">The cache used to store blob metadata. The lifetime of this cache is owned by the caller.</param>
+    /// <param name="cache">The shared <see cref="HybridCache" /> used to store blob metadata.</param>
     /// <param name="cacheOptions">The cache options supplying the absolute expirations for found and not-found entries.</param>
     /// <exception cref="System.ArgumentNullException"><paramref name="containerClient" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="cache" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="cacheOptions" /> is <c>null</c>.</exception>
-    public AzureBlobFileProvider(BlobContainerClient containerClient, string? containerRootPath, IMemoryCache cache, AzureBlobFileSystemCacheOptions cacheOptions)
+    public AzureBlobFileProvider(BlobContainerClient containerClient, string? containerRootPath, HybridCache cache, AzureBlobFileSystemCacheOptions cacheOptions)
         : this(containerClient, containerRootPath)
     {
-        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
-        _cacheOptions = cacheOptions ?? throw new ArgumentNullException(nameof(cacheOptions));
+        ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(cacheOptions);
+
+        if (cacheOptions.Enabled is true)
+        {
+            _cache = (
+                cache,
+                new HybridCacheEntryOptions
+                {
+                    Expiration = cacheOptions.HitDuration,
+                    LocalCacheExpiration = cacheOptions.HitDuration,
+                    Flags = HybridCacheEntryFlags.DisableDistributedCache,
+                },
+                new HybridCacheEntryOptions
+                {
+                    Expiration = cacheOptions.MissDuration,
+                    LocalCacheExpiration = cacheOptions.MissDuration,
+                    Flags = HybridCacheEntryFlags.DisableDistributedCache,
+                });
+        }
     }
 
     /// <summary>
@@ -62,16 +81,14 @@ public sealed class AzureBlobFileProvider : IFileProvider
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AzureBlobFileProvider" /> class with blob metadata caching backed by a caller-supplied <see cref="IMemoryCache" />.
+    /// Initializes a new instance of the <see cref="AzureBlobFileProvider" /> class with blob metadata caching backed by a caller-supplied <see cref="HybridCache" />.
     /// </summary>
     /// <param name="options">The options.</param>
-    /// <param name="cache">The cache used to store blob metadata. The lifetime of this cache is owned by the caller.</param>
-    /// <param name="cacheOptions">The cache options supplying the absolute expirations for found and not-found entries.</param>
+    /// <param name="cache">The shared <see cref="HybridCache" /> used to store blob metadata.</param>
     /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="cache" /> is <c>null</c>.</exception>
-    /// <exception cref="System.ArgumentNullException"><paramref name="cacheOptions" /> is <c>null</c>.</exception>
-    public AzureBlobFileProvider(AzureBlobFileSystemOptions options, IMemoryCache cache, AzureBlobFileSystemCacheOptions cacheOptions)
-        : this(GetContainerClient(options), options.ContainerRootPath, cache, cacheOptions)
+    public AzureBlobFileProvider(AzureBlobFileSystemOptions options, HybridCache cache)
+        : this(GetContainerClient(options), options.ContainerRootPath, cache, options.Cache)
     { }
 
     /// <inheritdoc />
@@ -92,75 +109,94 @@ public sealed class AzureBlobFileProvider : IFileProvider
     {
         var path = GetFullPath(subpath);
 
-        if (TryGetFromCache(path, out IFileInfo? cached))
+        if (_cache is not (var cache, var hitEntryOptions, var missEntryOptions))
         {
-            return cached;
+            return Fetch(path);
         }
 
-        BlobClient blobClient = _containerClient.GetBlobClient(path);
+        string cacheKey = CreateCacheKey(_containerClient, path);
 
-        IFileInfo fileInfo;
-        bool found;
-        try
+        // IFileProvider.GetFileInfo is sync; HybridCache is async. Block once at the contract boundary.
+        // Stampede protection inside HybridCache ensures concurrent callers for the same key share a single fetch.
+        // Stateful overload + static lambda avoids a per-call closure allocation.
+        // CachedFileInfo wrapper is [ImmutableObject(true)] so HybridCache stores by reference rather than
+        // serializing — IFileInfo is an interface which System.Text.Json cannot deserialize.
+        ValueTask<CachedFileInfo> getTask = cache.GetOrCreateAsync(
+            cacheKey,
+            (Provider: this, Path: path),
+            static (state, ct) => state.Provider.FetchAsync(state.Path, ct),
+            hitEntryOptions);
+
+        CachedFileInfo cached = getTask.IsCompletedSuccessfully
+            ? getTask.Result
+            : getTask.AsTask().GetAwaiter().GetResult();
+
+        // Optimistic HitDuration was applied above; shorten to MissDuration for not-found results
+        // so newly-uploaded blobs become visible quickly.
+        if (!cached.Value.Exists)
         {
-            BlobProperties properties = blobClient.GetProperties().Value;
-            fileInfo = new AzureBlobItemInfo(blobClient, properties);
-            found = true;
-        }
-        catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
-        {
-            fileInfo = new NotFoundFileInfo(AzureBlobItemInfo.ParseName(path));
-            found = false;
+            ValueTask setTask = cache.SetAsync(cacheKey, cached, missEntryOptions);
+            if (!setTask.IsCompletedSuccessfully)
+            {
+                setTask.AsTask().GetAwaiter().GetResult();
+            }
         }
 
-        TrySetCache(path, fileInfo, found);
-
-        return fileInfo;
+        return cached.Value;
     }
 
     /// <inheritdoc />
     public IChangeToken Watch(string filter) => NullChangeToken.Singleton;
 
+    /// <summary>
+    /// Builds the <see cref="HybridCache" /> key for a blob. This is the single place a cache key is constructed,
+    /// so the read path (<see cref="GetFileInfo" />) and the write-invalidation path (<see cref="IO.AzureBlobFileSystem" />) can never diverge.
+    /// </summary>
+    /// <param name="containerClient">The container client the blob belongs to.</param>
+    /// <param name="blobPath">The container-relative blob path.</param>
+    /// <returns>
+    /// A cache key namespaced to this package and the storage account/container.
+    /// </returns>
+    internal static string CreateCacheKey(BlobContainerClient containerClient, string blobPath)
+    {
+        // Hash the (potentially long, partly untrusted) blob path so the key stays well under HybridCache's
+        // MaximumKeyLength (1024 by default) no matter how deep the request path is; an over-long key silently
+        // bypasses the cache. XxHash128 is fast and non-cryptographic — a collision merely serves another blob's
+        // metadata until the entry expires or is invalidated, an acceptable trade for a metadata cache. The
+        // account/container are kept readable to keep keys diagnosable, and the literal prefix avoids collisions
+        // with other consumers of the shared HybridCache.
+        UInt128 hash = XxHash128.HashToUInt128(MemoryMarshal.AsBytes(blobPath.AsSpan()));
+
+        return $"Umbraco.StorageProviders.AzureBlob:{containerClient.AccountName}:{containerClient.Name}:{hash:x32}";
+    }
+
     private string GetFullPath(string subpath) => _containerRootPath + subpath.EnsureStartsWith('/');
 
-    private bool TryGetFromCache(string path, [NotNullWhen(true)] out IFileInfo? value)
+    private IFileInfo Fetch(string path)
     {
-        if (_cache is null)
-        {
-            value = null;
-            return false;
-        }
-
+        BlobClient blobClient = _containerClient.GetBlobClient(path);
         try
         {
-            return _cache.TryGetValue(path, out value) && value is not null;
+            return new AzureBlobItemInfo(blobClient, blobClient.GetProperties().Value);
         }
-        catch (ObjectDisposedException)
+        catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
         {
-            // Cache was disposed mid-request (options change or app shutdown); fall through to fetch from blob.
-            value = null;
-            return false;
+            return new NotFoundFileInfo(AzureBlobItemInfo.ParseName(path));
         }
     }
 
-    private void TrySetCache(string path, IFileInfo fileInfo, bool found)
+    private async ValueTask<CachedFileInfo> FetchAsync(string path, CancellationToken cancellationToken)
     {
-        if (_cache is null || _cacheOptions is null)
-        {
-            return;
-        }
-
+        BlobClient blobClient = _containerClient.GetBlobClient(path);
         try
         {
-            _cache.Set(path, fileInfo, new MemoryCacheEntryOptions
-            {
-                AbsoluteExpirationRelativeToNow = found ? _cacheOptions.HitDuration : _cacheOptions.MissDuration,
-                Size = 1,
-            });
+            Response<BlobProperties> response = await blobClient.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            return new CachedFileInfo(new AzureBlobItemInfo(blobClient, response.Value));
         }
-        catch (ObjectDisposedException)
+        catch (RequestFailedException ex) when (ex.Status == (int)HttpStatusCode.NotFound)
         {
-            // Cache was disposed mid-request (options change or app shutdown); skip caching this entry.
+            return new CachedFileInfo(new NotFoundFileInfo(AzureBlobItemInfo.ParseName(path)));
         }
     }
 
@@ -170,4 +206,11 @@ public sealed class AzureBlobFileProvider : IFileProvider
 
         return options.CreateBlobContainerClient();
     }
+
+    // Immutable wrapper around IFileInfo. HybridCache's ImmutableTypeCache<T> sees [ImmutableObject(true)]
+    // on this type and uses ImmutableCacheItem<T> (stored by reference, no serialization) instead of the
+    // default MutableCacheItem<T> which serializes via System.Text.Json — that path fails for IFileInfo
+    // because the interface cannot be deserialized polymorphically.
+    [ImmutableObject(true)]
+    private sealed record CachedFileInfo(IFileInfo Value);
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -37,7 +37,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// <exception cref="System.ArgumentNullException"><paramref name="hostingEnvironment" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
-    [Obsolete("Use the overload that accepts an HybridCache to enable blob metadata caching.")]
+    [Obsolete("Use the overload that accepts a HybridCache to enable blob metadata caching.")]
     public AzureBlobFileSystem(AzureBlobFileSystemOptions options, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider)
         : this(GetRequestRootPath(options, hostingEnvironment), options.CreateBlobContainerClient(), ioHelper, contentTypeProvider, options.ContainerRootPath)
     { }
@@ -49,12 +49,11 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// <param name="hostingEnvironment">The hosting environment.</param>
     /// <param name="ioHelper">The I/O helper.</param>
     /// <param name="contentTypeProvider">The content type provider.</param>
-    /// <param name="hybridCache">The shared <see cref="HybridCache" /> used for blob metadata. Caching is only active when <see cref="AzureBlobFileSystemOptions.Cache" /> has <see cref="AzureBlobFileSystemCacheOptions.Enabled" /> set to <c>true</c>.</param>
+    /// <param name="hybridCache">The shared <see cref="HybridCache" /> used for blob metadata, or <c>null</c> to disable caching. Caching is also only active when <see cref="AzureBlobFileSystemOptions.Cache" /> has <see cref="AzureBlobFileSystemCacheOptions.Enabled" /> set to <c>true</c>.</param>
     /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="hostingEnvironment" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
-    /// <exception cref="System.ArgumentNullException"><paramref name="hybridCache" /> is <c>null</c>.</exception>
     public AzureBlobFileSystem(AzureBlobFileSystemOptions options, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider, HybridCache? hybridCache)
         : this(GetRequestRootPath(options, hostingEnvironment), options.CreateBlobContainerClient(), ioHelper, contentTypeProvider, options.ContainerRootPath, hybridCache, options.Cache)
     { }
@@ -71,7 +70,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// <exception cref="System.ArgumentNullException"><paramref name="blobContainerClient" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
-    [Obsolete("Use the overload that accepts an HybridCache to enable blob metadata caching.")]
+    [Obsolete("Use the overload that accepts a HybridCache to enable blob metadata caching.")]
     public AzureBlobFileSystem(string requestRootPath, BlobContainerClient blobContainerClient, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider, string? containerRootPath = null)
         : this(requestRootPath, blobContainerClient, ioHelper, contentTypeProvider, containerRootPath, null, null)
     { }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -3,7 +3,7 @@ using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Microsoft.AspNetCore.StaticFiles;
-using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.FileProviders;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
@@ -12,7 +12,7 @@ using Umbraco.Extensions;
 namespace Umbraco.StorageProviders.AzureBlob.IO;
 
 /// <inheritdoc />
-public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFactory, IDisposable
+public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFactory
 {
     // When not found, default to 1-1-1601 00:00:00 +00:00 for created/last modified and -1 for size to align with PhysicalFileSystem
     private static readonly DateTimeOffset _notFoundDateTimeOffset = DateTimeOffset.FromUnixTimeSeconds(-11644473600);
@@ -23,7 +23,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     private readonly BlobContainerClient _container;
     private readonly IIOHelper _ioHelper;
     private readonly IContentTypeProvider _contentTypeProvider;
-    private readonly MemoryCache? _cache;
+    private readonly HybridCache? _cache;
     private readonly AzureBlobFileSystemCacheOptions? _cacheOptions;
 
     /// <summary>
@@ -37,8 +37,26 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// <exception cref="System.ArgumentNullException"><paramref name="hostingEnvironment" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
+    [Obsolete("Use the overload that accepts an HybridCache to enable blob metadata caching.")]
     public AzureBlobFileSystem(AzureBlobFileSystemOptions options, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider)
-        : this(GetRequestRootPath(options, hostingEnvironment), options.CreateBlobContainerClient(), ioHelper, contentTypeProvider, options.ContainerRootPath, options.Cache)
+        : this(GetRequestRootPath(options, hostingEnvironment), options.CreateBlobContainerClient(), ioHelper, contentTypeProvider, options.ContainerRootPath)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class with blob metadata caching backed by the supplied <see cref="HybridCache" />.
+    /// </summary>
+    /// <param name="options">The Azure Blob File System options.</param>
+    /// <param name="hostingEnvironment">The hosting environment.</param>
+    /// <param name="ioHelper">The I/O helper.</param>
+    /// <param name="contentTypeProvider">The content type provider.</param>
+    /// <param name="hybridCache">The shared <see cref="HybridCache" /> used for blob metadata. Caching is only active when <see cref="AzureBlobFileSystemOptions.Cache" /> has <see cref="AzureBlobFileSystemCacheOptions.Enabled" /> set to <c>true</c>.</param>
+    /// <exception cref="System.ArgumentNullException"><paramref name="options" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="hostingEnvironment" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="hybridCache" /> is <c>null</c>.</exception>
+    public AzureBlobFileSystem(AzureBlobFileSystemOptions options, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider, HybridCache? hybridCache)
+        : this(GetRequestRootPath(options, hostingEnvironment), options.CreateBlobContainerClient(), ioHelper, contentTypeProvider, options.ContainerRootPath, hybridCache, options.Cache)
     { }
 
     /// <summary>
@@ -53,25 +71,26 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// <exception cref="System.ArgumentNullException"><paramref name="blobContainerClient" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
-    [Obsolete("Use the overload that accepts an AzureBlobFileSystemCacheOptions to enable blob metadata caching.")]
+    [Obsolete("Use the overload that accepts an HybridCache to enable blob metadata caching.")]
     public AzureBlobFileSystem(string requestRootPath, BlobContainerClient blobContainerClient, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider, string? containerRootPath = null)
-        : this(requestRootPath, blobContainerClient, ioHelper, contentTypeProvider, containerRootPath, cacheOptions: null)
+        : this(requestRootPath, blobContainerClient, ioHelper, contentTypeProvider, containerRootPath, null, null)
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class.
+    /// Initializes a new instance of the <see cref="AzureBlobFileSystem"/> class with blob metadata caching backed by the supplied <see cref="HybridCache" />.
     /// </summary>
     /// <param name="requestRootPath">The request/URL root path.</param>
     /// <param name="blobContainerClient">The blob container client.</param>
     /// <param name="ioHelper">The I/O helper.</param>
     /// <param name="contentTypeProvider">The content type provider.</param>
     /// <param name="containerRootPath">The container root path (uses the request/URL root path if not set).</param>
-    /// <param name="cacheOptions">The blob metadata cache options applied to the read-only file provider. When <c>null</c>, caching is disabled.</param>
+    /// <param name="hybridCache">The shared <see cref="HybridCache" /> used for blob metadata.</param>
+    /// <param name="cacheOptions">The blob metadata cache options. Caching is only active when <see cref="AzureBlobFileSystemCacheOptions.Enabled" /> is <c>true</c>.</param>
     /// <exception cref="System.ArgumentNullException"><paramref name="requestRootPath" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="blobContainerClient" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="ioHelper" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="contentTypeProvider" /> is <c>null</c>.</exception>
-    public AzureBlobFileSystem(string requestRootPath, BlobContainerClient blobContainerClient, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider, string? containerRootPath, AzureBlobFileSystemCacheOptions? cacheOptions)
+    public AzureBlobFileSystem(string requestRootPath, BlobContainerClient blobContainerClient, IIOHelper ioHelper, IContentTypeProvider contentTypeProvider, string? containerRootPath, HybridCache? hybridCache, AzureBlobFileSystemCacheOptions? cacheOptions)
     {
         ArgumentNullException.ThrowIfNull(requestRootPath);
 
@@ -83,7 +102,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
 
         if (cacheOptions?.Enabled == true)
         {
-            _cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = cacheOptions.SizeLimit });
+            _cache = hybridCache;
             _cacheOptions = cacheOptions;
         }
     }
@@ -430,9 +449,6 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
         ? new AzureBlobFileProvider(_container, _containerRootPath)
         : new AzureBlobFileProvider(_container, _containerRootPath, _cache, _cacheOptions);
 
-    /// <inheritdoc />
-    public void Dispose() => _cache?.Dispose();
-
     private void InvalidateCacheEntry(string blobName)
     {
         if (_cache is null)
@@ -440,13 +456,11 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
             return;
         }
 
-        try
+        // HybridCache.RemoveAsync is async; the IFileSystem write methods are sync, so block here.
+        ValueTask removeTask = _cache.RemoveAsync(AzureBlobFileProvider.CreateCacheKey(_container, blobName));
+        if (!removeTask.IsCompletedSuccessfully)
         {
-            _cache.Remove(blobName);
-        }
-        catch (ObjectDisposedException)
-        {
-            // Cache was disposed during the call (options change or app shutdown); nothing to invalidate.
+            removeTask.AsTask().GetAwaiter().GetResult();
         }
     }
 

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemCacheOptions.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemCacheOptions.cs
@@ -1,25 +1,25 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
-using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Caching.Hybrid;
 
 namespace Umbraco.StorageProviders.AzureBlob.IO;
 
 /// <summary>
-/// In-memory cache settings applied to blob metadata lookups performed by the read-only file provider.
+/// Cache settings applied to blob metadata lookups performed by the read-only file provider.
 /// </summary>
 /// <remarks>
 /// Caching blob metadata (size, last modified) avoids a network round-trip to Azure Blob Storage
 /// on every media request. Under load the default Azure SDK retry policy can hold a thread for many seconds
 /// per call, so eliminating the round-trip for the steady-state hot path significantly reduces both latency
-/// and thread-pool pressure. Metadata is cached per blob path with a short absolute expiration.
+/// and thread-pool pressure. Backed by <see cref="HybridCache" />, which provides built-in stampede protection
+/// so concurrent requests for the same cold key share a single fetch.
 /// </remarks>
 public sealed class AzureBlobFileSystemCacheOptions : IValidatableObject
 {
     private const bool DefaultEnabled = true;
     private const string DefaultHitDuration = "00:00:30";
     private const string DefaultMissDuration = "00:00:05";
-    private const long DefaultSizeLimit = 10_000;
 
     /// <summary>
     /// Gets or sets a value indicating whether blob metadata caching is enabled.
@@ -57,19 +57,6 @@ public sealed class AzureBlobFileSystemCacheOptions : IValidatableObject
     /// </remarks>
     [DefaultValue(typeof(TimeSpan), DefaultMissDuration)]
     public TimeSpan MissDuration { get; set; } = TimeSpan.Parse(DefaultMissDuration, CultureInfo.InvariantCulture);
-
-    /// <summary>
-    /// Gets or sets the maximum number of cached <see cref="IFileInfo" /> entries.
-    /// </summary>
-    /// <value>
-    /// The cache size limit.
-    /// </value>
-    /// <remarks>
-    /// Each cache entry counts as a single unit. Defaults to 10,000 entries.
-    /// </remarks>
-    [DefaultValue(DefaultSizeLimit)]
-    [Range(0, long.MaxValue, ErrorMessage = "{0} must be a non-negative integer.")]
-    public long SizeLimit { get; set; } = DefaultSizeLimit;
 
     /// <inheritdoc />
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemProvider.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemProvider.cs
@@ -27,7 +27,7 @@ public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider, 
     /// <exception cref="ArgumentNullException"><paramref name="optionsMonitor"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="hostingEnvironment"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="ioHelper"/> is <c>null</c>.</exception>
-    [Obsolete("Use the overload that accepts an HybridCache to enable blob metadata caching.")]
+    [Obsolete("Use the overload that accepts a HybridCache to enable blob metadata caching.")]
     public AzureBlobFileSystemProvider(IOptionsMonitor<AzureBlobFileSystemOptions> optionsMonitor, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper)
         : this(optionsMonitor, hostingEnvironment, ioHelper, null)
     { }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemProvider.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystemProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Options;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.IO;
@@ -13,6 +14,7 @@ public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider, 
     private readonly IOptionsMonitor<AzureBlobFileSystemOptions> _optionsMonitor;
     private readonly IHostingEnvironment _hostingEnvironment;
     private readonly IIOHelper _ioHelper;
+    private readonly HybridCache? _hybridCache;
     private readonly FileExtensionContentTypeProvider _fileExtensionContentTypeProvider;
     private readonly IDisposable? _onChangeRegistration;
 
@@ -25,20 +27,30 @@ public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider, 
     /// <exception cref="ArgumentNullException"><paramref name="optionsMonitor"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="hostingEnvironment"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentNullException"><paramref name="ioHelper"/> is <c>null</c>.</exception>
+    [Obsolete("Use the overload that accepts an HybridCache to enable blob metadata caching.")]
     public AzureBlobFileSystemProvider(IOptionsMonitor<AzureBlobFileSystemOptions> optionsMonitor, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper)
+        : this(optionsMonitor, hostingEnvironment, ioHelper, null)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureBlobFileSystemProvider"/> class with blob metadata caching backed by the supplied <see cref="HybridCache" />.
+    /// </summary>
+    /// <param name="optionsMonitor">The options monitor.</param>
+    /// <param name="hostingEnvironment">The hosting environment.</param>
+    /// <param name="ioHelper">The IO helper.</param>
+    /// <param name="hybridCache">The shared <see cref="HybridCache" /> used by all file systems for blob metadata. When <c>null</c>, caching is disabled.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="optionsMonitor"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="hostingEnvironment"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="ioHelper"/> is <c>null</c>.</exception>
+    public AzureBlobFileSystemProvider(IOptionsMonitor<AzureBlobFileSystemOptions> optionsMonitor, IHostingEnvironment hostingEnvironment, IIOHelper ioHelper, HybridCache? hybridCache)
     {
         _optionsMonitor = optionsMonitor ?? throw new ArgumentNullException(nameof(optionsMonitor));
         _hostingEnvironment = hostingEnvironment ?? throw new ArgumentNullException(nameof(hostingEnvironment));
         _ioHelper = ioHelper ?? throw new ArgumentNullException(nameof(ioHelper));
+        _hybridCache = hybridCache;
         _fileExtensionContentTypeProvider = new FileExtensionContentTypeProvider();
 
-        _onChangeRegistration = _optionsMonitor.OnChange((options, name) =>
-        {
-            if (_fileSystems.TryRemove(name ?? Options.DefaultName, out IAzureBlobFileSystem? removed) && removed is IDisposable disposable)
-            {
-                disposable.Dispose();
-            }
-        });
+        _onChangeRegistration = _optionsMonitor.OnChange((options, name) => _fileSystems.TryRemove(name ?? Options.DefaultName, out _));
     }
 
     /// <inheritdoc />
@@ -51,23 +63,10 @@ public sealed class AzureBlobFileSystemProvider : IAzureBlobFileSystemProvider, 
         {
             AzureBlobFileSystemOptions options = _optionsMonitor.Get(name);
 
-            return new AzureBlobFileSystem(options, _hostingEnvironment, _ioHelper, _fileExtensionContentTypeProvider);
+            return new AzureBlobFileSystem(options, _hostingEnvironment, _ioHelper, _fileExtensionContentTypeProvider, _hybridCache);
         });
     }
 
     /// <inheritdoc />
-    public void Dispose()
-    {
-        _onChangeRegistration?.Dispose();
-
-        foreach (IAzureBlobFileSystem fileSystem in _fileSystems.Values)
-        {
-            if (fileSystem is IDisposable disposable)
-            {
-                disposable.Dispose();
-            }
-        }
-
-        _fileSystems.Clear();
-    }
+    public void Dispose() => _onChangeRegistration?.Dispose();
 }

--- a/src/Umbraco.StorageProviders.AzureBlob/Umbraco.StorageProviders.AzureBlob.csproj
+++ b/src/Umbraco.StorageProviders.AzureBlob/Umbraco.StorageProviders.AzureBlob.csproj
@@ -6,8 +6,10 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Web.Common" />
     <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
+    <PackageReference Include="System.IO.Hashing" />
+    <PackageReference Include="Umbraco.Cms.Web.Common" />
     <ProjectReference Include="..\Umbraco.StorageProviders\Umbraco.StorageProviders.csproj" />
   </ItemGroup>
   


### PR DESCRIPTION
Replaces the in-memory `IMemoryCache` blob-metadata caching added in #84 with the shared `HybridCache` now that the target framework is .NET 10.

## Why
`HybridCache` provides built-in stampede protection, so concurrent requests for the same cold blob path share a single `GetProperties()` fetch instead of each issuing their own. It also reuses the shared cache instance registered by Umbraco rather than each file system owning and disposing its own `MemoryCache`.

## What changed
- `AzureBlobFileProvider` and `AzureBlobFileSystem` use the injected `HybridCache` instead of a per-instance `MemoryCache`. Found metadata is cached for `HitDuration`, not-found for the shorter `MissDuration`, with the distributed tier disabled (in-process only).
- Cached values are wrapped in an `[ImmutableObject(true)]` record so `HybridCache` stores them by reference instead of serializing (an `IFileInfo` interface can't be round-tripped by `System.Text.Json`).
- Removed `SizeLimit` from `AzureBlobFileSystemCacheOptions` — `HybridCache` manages its own L1 sizing. The generated appsettings schema drops it automatically.
- Cache keys are now built in a single helper (`AzureBlobFileProvider.CreateCacheKey`) used by both the read and invalidation paths so they can't diverge. Keys are namespaced (`Umbraco.StorageProviders.AzureBlob:{account}:{container}:`) to avoid collisions with other consumers of the shared cache, and the blob path is hashed with `XxHash128` so the key stays well under `HybridCache`'s `MaximumKeyLength` regardless of request path length. Case is preserved because Azure blob names are case-sensitive.
- Back-compat constructor overloads kept and marked `[Obsolete]`; `AzureBlobFileSystem` no longer implements `IDisposable` as it no longer owns the cache.
- Added the `System.IO.Hashing` and `Microsoft.Extensions.Caching.Hybrid` package references; updated the README cache section.

Relies on the `HybridCache` already registered by Umbraco, so no additional `AddHybridCache()` call is needed.
