### PR TITLE
Implement IFileSystem.MoveFile on AzureBlobFileSystem

### DIFF
--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -202,16 +202,13 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// <inheritdoc />
     /// <exception cref="System.ArgumentNullException"><paramref name="path" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="stream" /> is <c>null</c>.</exception>
+    /// <exception cref="System.IO.IOException">A file already exists at <paramref name="path" /> and <paramref name="overrideIfExists" /> is <c>false</c>.</exception>
     public void AddFile(string path, Stream stream, bool overrideIfExists)
     {
         ArgumentNullException.ThrowIfNull(path);
         ArgumentNullException.ThrowIfNull(stream);
 
         BlobClient blob = GetBlobClient(path);
-        if (!overrideIfExists && blob.Exists())
-        {
-            throw new InvalidOperationException($"A file at path '{path}' already exists.");
-        }
 
         var headers = new BlobHttpHeaders();
         if (_contentTypeProvider.TryGetContentType(path, out var contentType))
@@ -219,6 +216,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
             headers.ContentType = contentType;
         }
 
+        // Enforce no-overwrite atomically via a precondition to avoid a check-then-write race
         BlobRequestConditions? conditions = overrideIfExists ? null : new BlobRequestConditions
         {
             IfNoneMatch = ETag.All
@@ -232,6 +230,10 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
                 Conditions = conditions
             });
         }
+        catch (RequestFailedException ex) when (!overrideIfExists && ex.Status is (int)HttpStatusCode.Conflict or (int)HttpStatusCode.PreconditionFailed)
+        {
+            throw new IOException($"A file at path '{path}' already exists.", ex);
+        }
         finally
         {
             InvalidateCacheEntry(blob.Name);
@@ -241,18 +243,16 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     /// <inheritdoc />
     /// <exception cref="System.ArgumentNullException"><paramref name="path" /> is <c>null</c>.</exception>
     /// <exception cref="System.ArgumentNullException"><paramref name="physicalPath" /> is <c>null</c>.</exception>
+    /// <exception cref="System.IO.IOException">A file already exists at <paramref name="path" /> and <paramref name="overrideIfExists" /> is <c>false</c>.</exception>
     public void AddFile(string path, string physicalPath, bool overrideIfExists = true, bool copy = false)
     {
         ArgumentNullException.ThrowIfNull(path);
         ArgumentNullException.ThrowIfNull(physicalPath);
 
         BlobClient destinationBlob = GetBlobClient(path);
-        if (!overrideIfExists && destinationBlob.Exists())
-        {
-            throw new InvalidOperationException($"A file at path '{path}' already exists.");
-        }
-
         BlobClient sourceBlob = GetBlobClient(physicalPath);
+
+        // Enforce no-overwrite atomically via a precondition to avoid a check-then-copy race
         BlobRequestConditions? destinationConditions = overrideIfExists ? null : new BlobRequestConditions
         {
             IfNoneMatch = ETag.All
@@ -265,7 +265,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
                 DestinationConditions = destinationConditions
             });
 
-            if (copyFromUriOperation?.HasCompleted == false)
+            if (!copyFromUriOperation.HasCompleted)
             {
                 copyFromUriOperation.WaitForCompletion();
             }
@@ -274,6 +274,10 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
             {
                 sourceBlob.DeleteIfExists();
             }
+        }
+        catch (RequestFailedException ex) when (!overrideIfExists && ex.Status is (int)HttpStatusCode.Conflict or (int)HttpStatusCode.PreconditionFailed)
+        {
+            throw new IOException($"A file at path '{path}' already exists.", ex);
         }
         finally
         {
@@ -306,9 +310,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
 
         BlobClient destinationBlob = GetBlobClient(target);
 
-        // Enforce the no-overwrite behavior atomically using a precondition (instead of a separate
-        // existence check that is subject to a race) so a concurrent writer can't have the target
-        // created between the check and the copy.
+        // Enforce no-overwrite atomically via a precondition to avoid a check-then-copy race
         BlobRequestConditions? destinationConditions = overrideIfExists ? null : new BlobRequestConditions
         {
             IfNoneMatch = ETag.All
@@ -321,7 +323,7 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
                 DestinationConditions = destinationConditions
             });
 
-            if (copyFromUriOperation?.HasCompleted == false)
+            if (!copyFromUriOperation.HasCompleted)
             {
                 copyFromUriOperation.WaitForCompletion();
             }

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -286,6 +286,49 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
     }
 
     /// <inheritdoc />
+    /// <exception cref="System.ArgumentNullException"><paramref name="source" /> is <c>null</c>.</exception>
+    /// <exception cref="System.ArgumentNullException"><paramref name="target" /> is <c>null</c>.</exception>
+    /// <exception cref="System.IO.FileNotFoundException">No file exists at <paramref name="source" />.</exception>
+    /// <exception cref="System.IO.IOException">A file already exists at <paramref name="target" /> and <paramref name="overrideIfExists" /> is <c>false</c>.</exception>
+    /// <remarks>
+    /// Moves the blob using a server-side copy followed by deleting the source, avoiding downloading and re-uploading the content.
+    /// </remarks>
+    public void MoveFile(string source, string target, bool overrideIfExists = true)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(target);
+
+        BlobClient sourceBlob = GetBlobClient(source);
+        if (!sourceBlob.Exists())
+        {
+            throw new FileNotFoundException($"File at path '{source}' could not be found.");
+        }
+
+        BlobClient destinationBlob = GetBlobClient(target);
+        if (!overrideIfExists && destinationBlob.Exists())
+        {
+            throw new IOException($"A file at path '{target}' already exists.");
+        }
+
+        try
+        {
+            CopyFromUriOperation copyFromUriOperation = destinationBlob.StartCopyFromUri(sourceBlob.Uri);
+
+            if (copyFromUriOperation?.HasCompleted == false)
+            {
+                copyFromUriOperation.WaitForCompletion();
+            }
+
+            sourceBlob.DeleteIfExists();
+        }
+        finally
+        {
+            InvalidateCacheEntry(destinationBlob.Name);
+            InvalidateCacheEntry(sourceBlob.Name);
+        }
+    }
+
+    /// <inheritdoc />
     /// <exception cref="System.ArgumentNullException"><paramref name="path" /> is <c>null</c>.</exception>
     public IEnumerable<string> GetFiles(string path)
     {

--- a/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
+++ b/src/Umbraco.StorageProviders.AzureBlob/IO/AzureBlobFileSystem.cs
@@ -305,14 +305,21 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
         }
 
         BlobClient destinationBlob = GetBlobClient(target);
-        if (!overrideIfExists && destinationBlob.Exists())
+
+        // Enforce the no-overwrite behavior atomically using a precondition (instead of a separate
+        // existence check that is subject to a race) so a concurrent writer can't have the target
+        // created between the check and the copy.
+        BlobRequestConditions? destinationConditions = overrideIfExists ? null : new BlobRequestConditions
         {
-            throw new IOException($"A file at path '{target}' already exists.");
-        }
+            IfNoneMatch = ETag.All
+        };
 
         try
         {
-            CopyFromUriOperation copyFromUriOperation = destinationBlob.StartCopyFromUri(sourceBlob.Uri);
+            CopyFromUriOperation copyFromUriOperation = destinationBlob.StartCopyFromUri(sourceBlob.Uri, new BlobCopyFromUriOptions()
+            {
+                DestinationConditions = destinationConditions
+            });
 
             if (copyFromUriOperation?.HasCompleted == false)
             {
@@ -320,6 +327,10 @@ public sealed class AzureBlobFileSystem : IAzureBlobFileSystem, IFileProviderFac
             }
 
             sourceBlob.DeleteIfExists();
+        }
+        catch (RequestFailedException ex) when (!overrideIfExists && ex.Status is (int)HttpStatusCode.Conflict or (int)HttpStatusCode.PreconditionFailed)
+        {
+            throw new IOException($"A file at path '{target}' already exists.", ex);
         }
         finally
         {


### PR DESCRIPTION
Fixes #81

The `IFileSystem.MoveFile(string source, string target, bool overrideIfExists = true)` method (added in CMS via umbraco/Umbraco-CMS#20378 and now available in v18) ships with a default implementation that downloads the source, re-uploads it to the target, then deletes the source. This overrides it on `AzureBlobFileSystem` with a more performant **server-side blob copy** (`StartCopyFromUri` + delete source), avoiding routing the content through the application — the same approach already used by the `AddFile(path, physicalPath, …)` overload.

## Behaviour

Matches the semantics of the interface default and `PhysicalFileSystem` reference implementation:

- Throws `FileNotFoundException` when no file exists at `source`.
- Throws `IOException` when a file already exists at `target` and `overrideIfExists` is `false`; otherwise the copy overwrites the target.
- Invalidates the `HybridCache` blob-metadata entries for both the source and target, consistent with the other write methods.

## Notes

- `AzureBlobFileSystem` is the only `IFileSystem` implementation in the repo (the ImageSharp cache implements `IImageCache`), so no other types needed updating.
- No unit-test project exists in this repository, so no test was added.