### PR TITLE
Pin Azure.Storage.Blobs to 12.27.0 to keep Microsoft.Extensions on 8.x (Umbraco 13)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,10 +12,13 @@
     <UmbracoCmsPackageVersion>[13.0.0, 14)</UmbracoCmsPackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Pinned to 12.28.0 (Azure.Core 1.51.1): 12.29.1 pulls Azure.Core 1.55.0, which requires
-         Microsoft.Extensions.* 10.0.3 even for net8 consumers and breaks Umbraco 13 (net8) restores
-         alongside Umbraco.Commerce (NU1608, Microsoft.Extensions.* [8.0.0, 9.0.0)). Do not bump on the 13.x line. -->
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
+    <!-- Pinned to 12.27.0: keeps the whole Azure.Core -> System.ClientModel chain on Microsoft.Extensions 8.x
+         (12.27.0 -> Azure.Core 1.50.0 -> System.ClientModel 1.8.0 -> Microsoft.Extensions.Logging.Abstractions 8.0.3).
+         Blobs 12.28.0+ pull Azure.Core 1.51.1+ -> System.ClientModel 1.9.0, which requires
+         Microsoft.Extensions.*.Abstractions 10.0.2/10.0.3 even for net8 consumers and breaks Umbraco 13 (net8)
+         restores against packages that cap Microsoft.Extensions below 9.0.0 (Umbraco.Commerce) or below 10.0.0
+         (Umbraco.Deploy/Rebus). Do not bump on the 13.x line. -->
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.2.0" />
     <PackageVersion Include="Umbraco.Cms.Imaging.ImageSharp" Version="$(UmbracoCmsPackageVersion)" />
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="$(UmbracoCmsPackageVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,10 @@
     <UmbracoCmsPackageVersion>[13.0.0, 14)</UmbracoCmsPackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <!-- Pinned to 12.28.0 (Azure.Core 1.51.1): 12.29.1 pulls Azure.Core 1.55.0, which requires
+         Microsoft.Extensions.* 10.0.3 even for net8 consumers and breaks Umbraco 13 (net8) restores
+         alongside Umbraco.Commerce (NU1608, Microsoft.Extensions.* [8.0.0, 9.0.0)). Do not bump on the 13.x line. -->
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.28.0" />
     <PackageVersion Include="SixLabors.ImageSharp.Web.Providers.Azure" Version="3.2.0" />
     <PackageVersion Include="Umbraco.Cms.Imaging.ImageSharp" Version="$(UmbracoCmsPackageVersion)" />
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="$(UmbracoCmsPackageVersion)" />

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "13.2.0",
+  "version": "13.2.1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
## Problem

After upgrading the Azure Blob storage provider **13.1.0 → 13.2.0**, .NET 8 / Umbraco 13 projects get `NU1608` restore warnings — `Microsoft.Extensions.*` resolving to `10.x`, outside the `[8.0.0, 9.0.0)` range that net8 packages declare. It surfaces most visibly alongside Umbraco.Commerce and also fails Umbraco Cloud auto-upgrades.

## Root cause

13.2.0 bumped `Azure.Storage.Blobs` to `12.29.1`, which pulls newer `Azure.Core` → `System.ClientModel`. The jump happens in **`System.ClientModel 1.9.0`**, which requires `Microsoft.Extensions.*.Abstractions` at `10.0.2` **even for net8 consumers**. NuGet then unifies the whole `Microsoft.Extensions.*` family up to 10.x.

This is not a bug in this package's code or in any consumer — it's an Azure SDK transitive dependency having moved to .NET 10 versions.

```
Azure.Storage.Blobs 12.29.1 → Azure.Core 1.55.0 → System.ClientModel 1.9.0
                                                   → Microsoft.Extensions.Logging/Configuration/Hosting.Abstractions 10.x
```

## Fix

Pin `Azure.Storage.Blobs` to **`12.27.0`**, which keeps the entire chain on `Microsoft.Extensions` **8.x**:

```
Azure.Storage.Blobs 12.27.0 → Azure.Core 1.50.0 → System.ClientModel 1.8.0
                                                   → Microsoft.Extensions.Logging.Abstractions 8.0.3
```

> Note: `12.28.0` is **not** sufficient — it resolves `Azure.Core 1.51.1 → System.ClientModel 1.9.0`, which still pulls `Microsoft.Extensions.* 10.0.2`. `12.27.0` (→ `Azure.Core 1.50.0 → System.ClientModel 1.8.0`) is the last version that stays on 8.x.

`SixLabors.ImageSharp.Web.Providers.Azure 3.2.0` is kept unchanged (it only requires `Azure.Storage.Blobs >= 12.25.0`). Targets **13.2.1** (`version.json`).

With this pin, no code changes or re-releases are needed in Umbraco.Commerce, Umbraco.Forms, or Umbraco.Deploy — their existing `Microsoft.Extensions.*` constraints (`< 9.0.0` / `< 10.0.0`) are satisfied as published. After this ships as 13.2.1, `Umbraco.Cloud.StorageProviders.AzureBlob` needs a rebuild/bump so the fix reaches Cloud customers (its floor `[13.2.0, 14)` otherwise resolves to 13.2.0).

## Verification

- [ ] CI restore/build on this PR
- [ ] Restore against a net8 / Umbraco 13 project with Commerce confirms `Microsoft.Extensions.*` stays on 8.x and the `NU1608` warnings are gone
- [ ] Sanity-check no Azure.Storage.Blobs security advisory mandates 12.28.0+

**Workaround until 13.2.1 is released:** stay on AzureBlob `13.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
